### PR TITLE
Add stop script to avoid docker compose down errors

### DIFF
--- a/examples/simple-passthrough-example/README.md
+++ b/examples/simple-passthrough-example/README.md
@@ -101,7 +101,7 @@ Command to run the consumer
 
 ### Stop / Clean
 ```bash
-docker compose down -v
+./stop.sh
 ```
 
 ### Notes

--- a/examples/simple-passthrough-example/stop.sh
+++ b/examples/simple-passthrough-example/stop.sh
@@ -1,0 +1,5 @@
+export GATEWAY_IMAGE="confluentinc/cpc-gateway:latest"
+export KAFKA_SERVER_JAAS_CONF="$(pwd)/kafka_server_jaas.conf"
+
+docker compose down -v || true
+docker container prune -f || true


### PR DESCRIPTION
Add `stop.sh` script to stop docker instances and clean up.
Running `docker compose down -v` when exported variables are not available in the shell would give errors like invalid spec.