### PR TITLE
fix: added log dir with necessary permissions

### DIFF
--- a/gateway/Dockerfile.ubi9
+++ b/gateway/Dockerfile.ubi9
@@ -56,9 +56,9 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && microdnf clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
-    && chown appuser:root -R /var/lib/${COMPONENT} /etc/${COMPONENT} /etc/${COMPONENT}/secrets \
-    && chmod -R ug+w /var/lib/${COMPONENT} /etc/${COMPONENT} /etc/${COMPONENT}/secrets
+    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /usr/logs \
+    && chown appuser:root -R /var/lib/${COMPONENT} /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs \
+    && chmod -R ug+w /var/lib/${COMPONENT} /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs
 
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]


### PR DESCRIPTION
This pull request makes a small but important update to the `gateway/Dockerfile.ubi9` setup process. The main change is the addition of the `/usr/logs` directory to the list of directories created, owned by `appuser:root`, and given write permissions.

Directory setup changes:

* Added `/usr/logs` to the directories created, ownership assignment, and write permissions to support logging requirements.