### PR TITLE
CPBR-3101: fixing DOCKER_UPSTREAM_TAG to ensure correct branch and RC cuts - 1.0.x

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -77,7 +77,7 @@ global_job_config:
       - export DOCKER_PROD_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/"
       - export DOCKER_UPSTREAM_REGISTRY=$DOCKER_PROD_REGISTRY
       - export LATEST_TAG=$BRANCH_TAG-latest
-      - export DOCKER_UPSTREAM_TAG="$LATEST_TAG"
+      - export DOCKER_UPSTREAM_TAG="8.1.x-latest"
       - export DOCKER_REPOS="confluentinc/cpc-gateway"
       - export MAVEN_EXTRA_ARGS=""
       - export DOCKER_DEV_TAG="dev-$BRANCH_TAG-$BUILD_NUMBER"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -66,7 +66,7 @@ global_job_config:
       - export DOCKER_PROD_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/"
       - export DOCKER_UPSTREAM_REGISTRY=$DOCKER_PROD_REGISTRY
       - export LATEST_TAG=$BRANCH_TAG-latest
-      - export DOCKER_UPSTREAM_TAG="$LATEST_TAG"
+      - export DOCKER_UPSTREAM_TAG="8.1.x-latest"
       - export DOCKER_REPOS="confluentinc/cpc-gateway"
       - export MAVEN_EXTRA_ARGS=""
       - export DOCKER_DEV_TAG="dev-$BRANCH_TAG-$BUILD_NUMBER"


### PR DESCRIPTION
regex added to replace DOCKER_UPSTREAM_TAG for branch and rc cut for this repo is `r"((?:master|\d+\.\d+\.x|\d+\.\d+\.\d+-rc\d+)-latest)"`. 

Right now the value is set to `$LATEST_TAG` which is incompatible with regex and is leading to value not getting set correctly during branch cut and RC cut. 

This PR sets the correct value for the field as per confluent.branch config in [cpc_gateway_versions.json](https://github.com/confluentinc/depot/blob/master/python/common_tools/data/prod/cpc_gateway_versions.json#L5) 