### PR TITLE
CPCG-488: Migrate gateway image from ubi9-minimal to ubi9-micro

### DIFF
--- a/confluent-gateway-for-cloud/Dockerfile.ubi9
+++ b/confluent-gateway-for-cloud/Dockerfile.ubi9
@@ -52,9 +52,11 @@ gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && mkdir -p /microdir
 
-RUN echo "===> Installing Temurin JRE and Gateway..." \
+RUN echo "===> Installing Temurin JRE..." \
     && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "temurin-21-jre${TEMURIN_JDK_VERSION}" \
+    && echo "===> Installing Gateway..." \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "confluent-gateway-${GATEWAY_VERSION}" \
        shadow-utils \
        coreutils \

--- a/confluent-gateway-for-cloud/Dockerfile.ubi9
+++ b/confluent-gateway-for-cloud/Dockerfile.ubi9
@@ -11,8 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG APP_UID=1000
+ARG APP_GID=1000
+
 ARG GOLANG_VERSION
-ARG UBI_MINIMAL_VERSION
+ARG UBI9_VERSION
+ARG UBI_MICRO_VERSION
+
+# Stage 1: Build ub utility binary
 FROM docker.io/golang:${GOLANG_VERSION} AS build-utilities
 
 ARG CP_DOCKER_UTILS_VERSION
@@ -21,16 +27,63 @@ ENV GO_BIN="/go/bin"
 RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}
 
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION}
+# Stage 2: Install packages to /microdir using full ubi9 with dnf
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 
+ARG APP_UID
+ARG APP_GID
+ARG TEMURIN_JDK_VERSION
+ARG GATEWAY_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+
+RUN printf "[temurin-jre] \n\
+name=temurin-jre \n\
+baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
+enabled=1 \n\
+gpgcheck=1 \n\
+gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
+" > /etc/yum.repos.d/adoptium.repo \
+    && rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
+    && printf "[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && mkdir -p /microdir
+
+RUN echo "===> Installing Temurin JRE and Gateway..." \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
+       "temurin-21-jre${TEMURIN_JDK_VERSION}" \
+       "confluent-gateway-${GATEWAY_VERSION}" \
+       shadow-utils \
+       coreutils \
+    && echo "===> Cleaning up ..." \
+    && dnf --installroot=/microdir clean all \
+    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \
+    && rm /etc/yum.repos.d/adoptium.repo /etc/yum.repos.d/confluent.repo \
+    && rm -rf /microdir/lib/systemd \
+    && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
+
+RUN echo "===> Creating appuser..." \
+    && chroot /microdir groupadd -g "${APP_GID}" appuser \
+    && chroot /microdir useradd -u "${APP_UID}" -g "${APP_GID}" --no-log-init --create-home --shell /bin/bash appuser
+
+
+# Stage 3: Final image using ubi9-micro
+FROM registry.access.redhat.com/ubi9-micro:${UBI_MICRO_VERSION}
+
+ARG APP_UID
+ARG APP_GID
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
 ARG BUILD_NUMBER=-1
-ARG TEMURIN_JDK_VERSION
 ARG GATEWAY_VERSION
-ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -50,61 +103,33 @@ ENV COMPONENT_CONFIG_DIR=/etc/confluent-${COMPONENT}
 
 USER root
 
-RUN printf "[temurin-jre] \n\
-name=temurin-jre \n\
-baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
-" > /etc/yum.repos.d/adoptium.repo \
-    && echo "===> Installing Temurin JRE..." \
-    && microdnf install -y temurin-21-jre${TEMURIN_JDK_VERSION} \
-    && microdnf clean all \
-    && echo "===> Creating appuser and directories..." \
-    && useradd --no-log-init --create-home --shell /bin/bash appuser \
-    && mkdir -p /etc/confluent/docker /usr/logs \
-    && chown appuser:appuser -R /etc/confluent/ /usr/logs \
-    && mkdir /licenses \
-    && rm /etc/yum.repos.d/adoptium.repo
-
 COPY --from=build-utilities /go/bin/ub /usr/bin/ub
+COPY --from=builder /microdir/ /
 
+RUN mkdir -p /etc/confluent/docker /usr/logs /licenses \
+    && chown "${APP_UID}:${APP_GID}" -R /etc/confluent/ /usr/logs
 
-RUN echo "===> Installing ${COMPONENT}..." \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
-    && printf "[Confluent] \n\
-name=Confluent repository \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${GATEWAY_VERSION} \
-    && echo "===> Cleaning up ..." \
-    && microdnf clean all \
-    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
-    && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /usr/logs \
-    && chown appuser:root -R /var/lib/${COMPONENT} /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs \
-    && chmod -R ug+w /var/lib/${COMPONENT} /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs
-
+RUN echo "===> Setting up ${COMPONENT} dirs" \
+    && mkdir -p "/var/lib/${COMPONENT}/data" "/etc/${COMPONENT}/secrets" /usr/logs \
+    && chown "${APP_UID}":root -R "/var/lib/${COMPONENT}" "/etc/${COMPONENT}" "/etc/${COMPONENT}/secrets" /usr/logs \
+    && chmod -R ug+w "/var/lib/${COMPONENT}" "/etc/${COMPONENT}" "/etc/${COMPONENT}/secrets" /usr/logs
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
 
-# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startups scripts)
-COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
-COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
+# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startup scripts)
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
 
 # /usr/share/java/cp-base-java is the default java classpath for ub
 # jars in cp-base-new and cp-base-java are identical, so create a symlink to avoid duplicating files
 RUN ln -s /usr/share/java/cp-base-new /usr/share/java/cp-base-java
 
-
-COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=${APP_UID}:${APP_GID} include/etc/confluent/docker /etc/confluent/docker
 COPY license.txt /licenses/
 
 RUN chmod +x /etc/confluent/docker/run
 RUN chmod +x /etc/confluent/docker/configure
 
-USER appuser
+USER ${APP_UID}
 
 CMD ["/etc/confluent/docker/run"]

--- a/confluent-gateway-for-cloud/Dockerfile.ubi9
+++ b/confluent-gateway-for-cloud/Dockerfile.ubi9
@@ -52,11 +52,9 @@ gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && mkdir -p /microdir
 
-RUN echo "===> Installing Temurin JRE..." \
+RUN echo "===> Installing Temurin JRE and Gateway..." \
     && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "temurin-21-jre${TEMURIN_JDK_VERSION}" \
-    && echo "===> Installing Gateway..." \
-    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "confluent-gateway-${GATEWAY_VERSION}" \
        shadow-utils \
        coreutils \

--- a/confluent-gateway-for-cloud/Dockerfile.ubi9
+++ b/confluent-gateway-for-cloud/Dockerfile.ubi9
@@ -18,13 +18,14 @@ ARG GOLANG_VERSION
 ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-# Stage 1: Build ub utility binary
+# Stage 1: Build ub and package_dedupe utility binaries
 FROM docker.io/golang:${GOLANG_VERSION} AS build-utilities
 
 ARG CP_DOCKER_UTILS_VERSION
 
 ENV GO_BIN="/go/bin"
 RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}
+RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/package_dedupe@${CP_DOCKER_UTILS_VERSION}
 
 
 # Stage 2: Install packages to /microdir using full ubi9 with dnf
@@ -104,6 +105,7 @@ ENV COMPONENT_CONFIG_DIR=/etc/confluent-${COMPONENT}
 USER root
 
 COPY --from=build-utilities /go/bin/ub /usr/bin/ub
+COPY --from=build-utilities /go/bin/package_dedupe /usr/local/bin/package_dedupe
 COPY --from=builder /microdir/ /
 
 RUN mkdir -p /etc/confluent/docker /usr/logs /licenses \
@@ -123,6 +125,9 @@ COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-pack
 # /usr/share/java/cp-base-java is the default java classpath for ub
 # jars in cp-base-new and cp-base-java are identical, so create a symlink to avoid duplicating files
 RUN ln -s /usr/share/java/cp-base-new /usr/share/java/cp-base-java
+
+RUN echo "===> Deduping jars in /usr/share/java ..." \
+    && /usr/local/bin/package_dedupe /usr/share/java
 
 COPY --chown=${APP_UID}:${APP_GID} include/etc/confluent/docker /etc/confluent/docker
 COPY license.txt /licenses/

--- a/confluent-gateway-for-cloud/Dockerfile.ubi9
+++ b/confluent-gateway-for-cloud/Dockerfile.ubi9
@@ -37,7 +37,6 @@ ARG APP_UID
 ARG APP_GID
 ARG TEMURIN_JDK_VERSION
 ARG SHADOW_UTILS_VERSION
-ARG SED_VERSION
 ARG GATEWAY_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG ARTIFACT_ID
@@ -66,7 +65,6 @@ RUN echo "===> Installing Temurin JRE and Gateway..." \
        "temurin-21-jre${TEMURIN_JDK_VERSION}" \
        "confluent-gateway-${GATEWAY_VERSION}" \
        "shadow-utils${SHADOW_UTILS_VERSION}" \
-       "sed${SED_VERSION}" \
     && echo "===> Cleaning up ..." \
     && dnf --installroot=/microdir clean all \
     && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \

--- a/confluent-gateway-for-cloud/Dockerfile.ubi9
+++ b/confluent-gateway-for-cloud/Dockerfile.ubi9
@@ -36,8 +36,14 @@ FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 ARG APP_UID
 ARG APP_GID
 ARG TEMURIN_JDK_VERSION
+ARG SHADOW_UTILS_VERSION
+ARG SED_VERSION
 ARG GATEWAY_VERSION
 ARG CONFLUENT_PACKAGES_REPO
+ARG ARTIFACT_ID
+ARG PROJECT_VERSION
+
+COPY --from=build-utilities /go/bin/package_dedupe /usr/local/bin/package_dedupe
 
 RUN printf "[temurin-jre] \n\
 name=temurin-jre \n\
@@ -59,8 +65,8 @@ RUN echo "===> Installing Temurin JRE and Gateway..." \
     && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "temurin-21-jre${TEMURIN_JDK_VERSION}" \
        "confluent-gateway-${GATEWAY_VERSION}" \
-       shadow-utils \
-       coreutils \
+       "shadow-utils${SHADOW_UTILS_VERSION}" \
+       "sed${SED_VERSION}" \
     && echo "===> Cleaning up ..." \
     && dnf --installroot=/microdir clean all \
     && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \
@@ -71,6 +77,16 @@ RUN echo "===> Installing Temurin JRE and Gateway..." \
 RUN echo "===> Creating appuser..." \
     && chroot /microdir groupadd -g "${APP_GID}" appuser \
     && chroot /microdir useradd -u "${APP_UID}" -g "${APP_GID}" --no-log-init --create-home --shell /bin/bash appuser
+
+# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startup scripts)
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /microdir/usr/share/doc/cp-base-new/
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /microdir/usr/share/java/cp-base-new/
+
+# /usr/share/java/cp-base-java is the default java classpath for ub
+# jars in cp-base-new and cp-base-java are identical, so create a symlink to avoid duplicating files
+RUN ln -s /usr/share/java/cp-base-new /microdir/usr/share/java/cp-base-java \
+    && echo "===> Deduping jars in /usr/share/java ..." \
+    && package_dedupe /microdir/usr/share/java
 
 
 # Stage 3: Final image using ubi9-micro
@@ -107,7 +123,6 @@ ENV COMPONENT_CONFIG_DIR=/etc/confluent-${COMPONENT}
 USER root
 
 COPY --from=build-utilities /go/bin/ub /usr/bin/ub
-COPY --from=build-utilities /go/bin/package_dedupe /usr/local/bin/package_dedupe
 COPY --from=builder /microdir/ /
 
 RUN mkdir -p /etc/confluent/docker /usr/logs /licenses \
@@ -119,17 +134,6 @@ RUN echo "===> Setting up ${COMPONENT} dirs" \
     && chmod -R ug+w "/var/lib/${COMPONENT}" "/etc/${COMPONENT}" "/etc/${COMPONENT}/secrets" /usr/logs
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
-
-# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startup scripts)
-COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
-COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
-
-# /usr/share/java/cp-base-java is the default java classpath for ub
-# jars in cp-base-new and cp-base-java are identical, so create a symlink to avoid duplicating files
-RUN ln -s /usr/share/java/cp-base-new /usr/share/java/cp-base-java
-
-RUN echo "===> Deduping jars in /usr/share/java ..." \
-    && /usr/local/bin/package_dedupe /usr/share/java
 
 COPY --chown=${APP_UID}:${APP_GID} include/etc/confluent/docker /etc/confluent/docker
 COPY license.txt /licenses/

--- a/confluent-gateway-for-cloud/Dockerfile.ubi9
+++ b/confluent-gateway-for-cloud/Dockerfile.ubi9
@@ -24,8 +24,10 @@ FROM docker.io/golang:${GOLANG_VERSION} AS build-utilities
 ARG CP_DOCKER_UTILS_VERSION
 
 ENV GO_BIN="/go/bin"
-RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/package_dedupe@${CP_DOCKER_UTILS_VERSION}
+RUN CGO_ENABLED=0 go install -ldflags="-w -s" \
+    "github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}"
+RUN CGO_ENABLED=0 go install -ldflags="-w -s" \
+    "github.com/confluentinc/cp-docker-utils/cmd/package_dedupe@${CP_DOCKER_UTILS_VERSION}"
 
 
 # Stage 2: Install packages to /microdir using full ubi9 with dnf

--- a/gateway/Dockerfile.ubi9
+++ b/gateway/Dockerfile.ubi9
@@ -52,9 +52,11 @@ gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && mkdir -p /microdir
 
-RUN echo "===> Installing Temurin JRE and Gateway..." \
+RUN echo "===> Installing Temurin JRE..." \
     && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "temurin-21-jre${TEMURIN_JDK_VERSION}" \
+    && echo "===> Installing Gateway..." \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "confluent-gateway-${GATEWAY_VERSION}" \
        shadow-utils \
        coreutils \

--- a/gateway/Dockerfile.ubi9
+++ b/gateway/Dockerfile.ubi9
@@ -11,8 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG APP_UID=1000
+ARG APP_GID=1000
+
 ARG GOLANG_VERSION
-ARG UBI_MINIMAL_VERSION
+ARG UBI9_VERSION
+ARG UBI_MICRO_VERSION
+
+# Stage 1: Build ub utility binary
 FROM docker.io/golang:${GOLANG_VERSION} AS build-utilities
 
 ARG CP_DOCKER_UTILS_VERSION
@@ -21,16 +27,63 @@ ENV GO_BIN="/go/bin"
 RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}
 
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION}
+# Stage 2: Install packages to /microdir using full ubi9 with dnf
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 
+ARG APP_UID
+ARG APP_GID
+ARG TEMURIN_JDK_VERSION
+ARG GATEWAY_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+
+RUN printf "[temurin-jre] \n\
+name=temurin-jre \n\
+baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
+enabled=1 \n\
+gpgcheck=1 \n\
+gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
+" > /etc/yum.repos.d/adoptium.repo \
+    && rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
+    && printf "[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && mkdir -p /microdir
+
+RUN echo "===> Installing Temurin JRE and Gateway..." \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
+       "temurin-21-jre${TEMURIN_JDK_VERSION}" \
+       "confluent-gateway-${GATEWAY_VERSION}" \
+       shadow-utils \
+       coreutils \
+    && echo "===> Cleaning up ..." \
+    && dnf --installroot=/microdir clean all \
+    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \
+    && rm /etc/yum.repos.d/adoptium.repo /etc/yum.repos.d/confluent.repo \
+    && rm -rf /microdir/lib/systemd \
+    && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
+
+RUN echo "===> Creating appuser..." \
+    && chroot /microdir groupadd -g "${APP_GID}" appuser \
+    && chroot /microdir useradd -u "${APP_UID}" -g "${APP_GID}" --no-log-init --create-home --shell /bin/bash appuser
+
+
+# Stage 3: Final image using ubi9-micro
+FROM registry.access.redhat.com/ubi9-micro:${UBI_MICRO_VERSION}
+
+ARG APP_UID
+ARG APP_GID
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
 ARG BUILD_NUMBER=-1
-ARG TEMURIN_JDK_VERSION
 ARG GATEWAY_VERSION
-ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -50,61 +103,33 @@ ENV COMPONENT_CONFIG_DIR=/etc/confluent-${COMPONENT}
 
 USER root
 
-RUN printf "[temurin-jre] \n\
-name=temurin-jre \n\
-baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
-" > /etc/yum.repos.d/adoptium.repo \
-    && echo "===> Installing Temurin JRE..." \
-    && microdnf install -y temurin-21-jre${TEMURIN_JDK_VERSION} \
-    && microdnf clean all \
-    && echo "===> Creating appuser and directories..." \
-    && useradd --no-log-init --create-home --shell /bin/bash appuser \
-    && mkdir -p /etc/confluent/docker /usr/logs \
-    && chown appuser:appuser -R /etc/confluent/ /usr/logs \
-    && mkdir /licenses \
-    && rm /etc/yum.repos.d/adoptium.repo
-
 COPY --from=build-utilities /go/bin/ub /usr/bin/ub
+COPY --from=builder /microdir/ /
 
+RUN mkdir -p /etc/confluent/docker /usr/logs /licenses \
+    && chown "${APP_UID}:${APP_GID}" -R /etc/confluent/ /usr/logs
 
-RUN echo "===> Installing ${COMPONENT}..." \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
-    && printf "[Confluent] \n\
-name=Confluent repository \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${GATEWAY_VERSION} \
-    && echo "===> Cleaning up ..." \
-    && microdnf clean all \
-    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
-    && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /usr/logs \
-    && chown appuser:root -R /var/lib/${COMPONENT} /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs \
-    && chmod -R ug+w /var/lib/${COMPONENT} /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs
-
+RUN echo "===> Setting up ${COMPONENT} dirs" \
+    && mkdir -p "/var/lib/${COMPONENT}/data" "/etc/${COMPONENT}/secrets" /usr/logs \
+    && chown "${APP_UID}":root -R "/var/lib/${COMPONENT}" "/etc/${COMPONENT}" "/etc/${COMPONENT}/secrets" /usr/logs \
+    && chmod -R ug+w "/var/lib/${COMPONENT}" "/etc/${COMPONENT}" "/etc/${COMPONENT}/secrets" /usr/logs
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
 
-# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startups scripts)
-COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
-COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
+# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startup scripts)
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
 
 # /usr/share/java/cp-base-java is the default java classpath for ub
 # jars in cp-base-new and cp-base-java are identical, so create a symlink to avoid duplicating files
 RUN ln -s /usr/share/java/cp-base-new /usr/share/java/cp-base-java
 
-
-COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=${APP_UID}:${APP_GID} include/etc/confluent/docker /etc/confluent/docker
 COPY license.txt /licenses/
 
 RUN chmod +x /etc/confluent/docker/run
 RUN chmod +x /etc/confluent/docker/configure
 
-USER appuser
+USER ${APP_UID}
 
 CMD ["/etc/confluent/docker/run"]

--- a/gateway/Dockerfile.ubi9
+++ b/gateway/Dockerfile.ubi9
@@ -52,11 +52,9 @@ gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && mkdir -p /microdir
 
-RUN echo "===> Installing Temurin JRE..." \
+RUN echo "===> Installing Temurin JRE and Gateway..." \
     && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "temurin-21-jre${TEMURIN_JDK_VERSION}" \
-    && echo "===> Installing Gateway..." \
-    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "confluent-gateway-${GATEWAY_VERSION}" \
        shadow-utils \
        coreutils \

--- a/gateway/Dockerfile.ubi9
+++ b/gateway/Dockerfile.ubi9
@@ -18,13 +18,14 @@ ARG GOLANG_VERSION
 ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-# Stage 1: Build ub utility binary
+# Stage 1: Build ub and package_dedupe utility binaries
 FROM docker.io/golang:${GOLANG_VERSION} AS build-utilities
 
 ARG CP_DOCKER_UTILS_VERSION
 
 ENV GO_BIN="/go/bin"
 RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}
+RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/package_dedupe@${CP_DOCKER_UTILS_VERSION}
 
 
 # Stage 2: Install packages to /microdir using full ubi9 with dnf
@@ -104,6 +105,7 @@ ENV COMPONENT_CONFIG_DIR=/etc/confluent-${COMPONENT}
 USER root
 
 COPY --from=build-utilities /go/bin/ub /usr/bin/ub
+COPY --from=build-utilities /go/bin/package_dedupe /usr/local/bin/package_dedupe
 COPY --from=builder /microdir/ /
 
 RUN mkdir -p /etc/confluent/docker /usr/logs /licenses \
@@ -123,6 +125,9 @@ COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-pack
 # /usr/share/java/cp-base-java is the default java classpath for ub
 # jars in cp-base-new and cp-base-java are identical, so create a symlink to avoid duplicating files
 RUN ln -s /usr/share/java/cp-base-new /usr/share/java/cp-base-java
+
+RUN echo "===> Deduping jars in /usr/share/java ..." \
+    && /usr/local/bin/package_dedupe /usr/share/java
 
 COPY --chown=${APP_UID}:${APP_GID} include/etc/confluent/docker /etc/confluent/docker
 COPY license.txt /licenses/

--- a/gateway/Dockerfile.ubi9
+++ b/gateway/Dockerfile.ubi9
@@ -37,7 +37,6 @@ ARG APP_UID
 ARG APP_GID
 ARG TEMURIN_JDK_VERSION
 ARG SHADOW_UTILS_VERSION
-ARG SED_VERSION
 ARG GATEWAY_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG ARTIFACT_ID
@@ -66,7 +65,6 @@ RUN echo "===> Installing Temurin JRE and Gateway..." \
        "temurin-21-jre${TEMURIN_JDK_VERSION}" \
        "confluent-gateway-${GATEWAY_VERSION}" \
        "shadow-utils${SHADOW_UTILS_VERSION}" \
-       "sed${SED_VERSION}" \
     && echo "===> Cleaning up ..." \
     && dnf --installroot=/microdir clean all \
     && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \

--- a/gateway/Dockerfile.ubi9
+++ b/gateway/Dockerfile.ubi9
@@ -36,8 +36,14 @@ FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 ARG APP_UID
 ARG APP_GID
 ARG TEMURIN_JDK_VERSION
+ARG SHADOW_UTILS_VERSION
+ARG SED_VERSION
 ARG GATEWAY_VERSION
 ARG CONFLUENT_PACKAGES_REPO
+ARG ARTIFACT_ID
+ARG PROJECT_VERSION
+
+COPY --from=build-utilities /go/bin/package_dedupe /usr/local/bin/package_dedupe
 
 RUN printf "[temurin-jre] \n\
 name=temurin-jre \n\
@@ -59,8 +65,8 @@ RUN echo "===> Installing Temurin JRE and Gateway..." \
     && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "temurin-21-jre${TEMURIN_JDK_VERSION}" \
        "confluent-gateway-${GATEWAY_VERSION}" \
-       shadow-utils \
-       coreutils \
+       "shadow-utils${SHADOW_UTILS_VERSION}" \
+       "sed${SED_VERSION}" \
     && echo "===> Cleaning up ..." \
     && dnf --installroot=/microdir clean all \
     && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \
@@ -71,6 +77,16 @@ RUN echo "===> Installing Temurin JRE and Gateway..." \
 RUN echo "===> Creating appuser..." \
     && chroot /microdir groupadd -g "${APP_GID}" appuser \
     && chroot /microdir useradd -u "${APP_UID}" -g "${APP_GID}" --no-log-init --create-home --shell /bin/bash appuser
+
+# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startup scripts)
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /microdir/usr/share/doc/cp-base-new/
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /microdir/usr/share/java/cp-base-new/
+
+# /usr/share/java/cp-base-java is the default java classpath for ub
+# jars in cp-base-new and cp-base-java are identical, so create a symlink to avoid duplicating files
+RUN ln -s /usr/share/java/cp-base-new /microdir/usr/share/java/cp-base-java \
+    && echo "===> Deduping jars in /usr/share/java ..." \
+    && package_dedupe /microdir/usr/share/java
 
 
 # Stage 3: Final image using ubi9-micro
@@ -107,7 +123,6 @@ ENV COMPONENT_CONFIG_DIR=/etc/confluent-${COMPONENT}
 USER root
 
 COPY --from=build-utilities /go/bin/ub /usr/bin/ub
-COPY --from=build-utilities /go/bin/package_dedupe /usr/local/bin/package_dedupe
 COPY --from=builder /microdir/ /
 
 RUN mkdir -p /etc/confluent/docker /usr/logs /licenses \
@@ -119,17 +134,6 @@ RUN echo "===> Setting up ${COMPONENT} dirs" \
     && chmod -R ug+w "/var/lib/${COMPONENT}" "/etc/${COMPONENT}" "/etc/${COMPONENT}/secrets" /usr/logs
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
-
-# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startup scripts)
-COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
-COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
-
-# /usr/share/java/cp-base-java is the default java classpath for ub
-# jars in cp-base-new and cp-base-java are identical, so create a symlink to avoid duplicating files
-RUN ln -s /usr/share/java/cp-base-new /usr/share/java/cp-base-java
-
-RUN echo "===> Deduping jars in /usr/share/java ..." \
-    && /usr/local/bin/package_dedupe /usr/share/java
 
 COPY --chown=${APP_UID}:${APP_GID} include/etc/confluent/docker /etc/confluent/docker
 COPY license.txt /licenses/

--- a/gateway/Dockerfile.ubi9
+++ b/gateway/Dockerfile.ubi9
@@ -24,8 +24,10 @@ FROM docker.io/golang:${GOLANG_VERSION} AS build-utilities
 ARG CP_DOCKER_UTILS_VERSION
 
 ENV GO_BIN="/go/bin"
-RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/package_dedupe@${CP_DOCKER_UTILS_VERSION}
+RUN CGO_ENABLED=0 go install -ldflags="-w -s" \
+    "github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}"
+RUN CGO_ENABLED=0 go install -ldflags="-w -s" \
+    "github.com/confluentinc/cp-docker-utils/cmd/package_dedupe@${CP_DOCKER_UTILS_VERSION}"
 
 
 # Stage 2: Install packages to /microdir using full ubi9 with dnf

--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,13 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <buildArgs>
-                        <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
-                        <ARCH>${arch.type}</ARCH>
+                        <APP_UID>${app.uid}</APP_UID>
+                        <APP_GID>${app.gid}</APP_GID>
+                        <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
+                        <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                         <GATEWAY_VERSION>${GATEWAY_VERSION}</GATEWAY_VERSION>
                         <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                        <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                        <TEMURIN_JDK_VERSION>-${ubi9.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
                         <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                     </buildArgs>
                 </configuration>
@@ -95,11 +97,13 @@
                         <image>
                             <build>
                                 <args>
-                                    <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
-                                    <ARCH>${arch.type}</ARCH>
+                                    <APP_UID>${app.uid}</APP_UID>
+                                    <APP_GID>${app.gid}</APP_GID>
+                                    <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
+                                    <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                                     <GATEWAY_VERSION>${GATEWAY_VERSION}</GATEWAY_VERSION>
                                     <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                                    <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                                    <TEMURIN_JDK_VERSION>-${ubi9.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
                                     <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                                 </args>
                             </build>
@@ -148,11 +152,16 @@
         the automation tooling can correctly identify and update them.
         -->
 
+        <!-- App User/Group IDs - can be overridden at build time via -Dapp.uid=<value> -Dapp.gid=<value> -->
+        <app.uid>1000</app.uid>
+        <app.gid>1000</app.gid>
+
         <!-- Base Image Versions -->
-        <ubi9-minimal.image.version>9.7-1775623882</ubi9-minimal.image.version>
+        <ubi9.image.version>9.7-1771346757</ubi9.image.version>
+        <ubi9-micro.image.version>9.7-1771346390</ubi9-micro.image.version>
 
         <!-- OS Package Versions -->
-        <ubi9-minimal.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9-minimal.temurin-21-jdk.version>
+        <ubi9.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9.temurin-21-jdk.version>
 
         <!-- GitHub Repository Tags -->
         <git-repo.cp-docker-utils.tag>v1.0.9</git-repo.cp-docker-utils.tag>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,8 @@
                                     <GATEWAY_VERSION>${GATEWAY_VERSION}</GATEWAY_VERSION>
                                     <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
                                     <TEMURIN_JDK_VERSION>-${ubi9.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                                    <SHADOW_UTILS_VERSION>-${ubi9.shadow-utils.version}</SHADOW_UTILS_VERSION>
+                                    <SED_VERSION>-${ubi9.sed.version}</SED_VERSION>
                                     <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                                 </args>
                             </build>
@@ -163,6 +165,8 @@
 
         <!-- OS Package Versions -->
         <ubi9.temurin-21-jdk.version>21.0.11.0.0.10-0</ubi9.temurin-21-jdk.version>
+        <ubi9.shadow-utils.version>4.9-16.el9</ubi9.shadow-utils.version>
+        <ubi9.sed.version>4.8-10.el9</ubi9.sed.version>
 
         <!-- GitHub Repository Tags -->
         <git-repo.cp-docker-utils.tag>v1.0.16</git-repo.cp-docker-utils.tag>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
                                     <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                                     <GATEWAY_VERSION>${GATEWAY_VERSION}</GATEWAY_VERSION>
                                     <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                                    <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                                    <TEMURIN_JDK_VERSION>-${ubi9.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
                                     <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                                 </args>
                             </build>
@@ -162,7 +162,7 @@
         <ubi9-micro.image.version>9.7-1771346390</ubi9-micro.image.version>
 
         <!-- OS Package Versions -->
-        <ubi9-minimal.temurin-21-jdk.version>21.0.11.0.0.10-0</ubi9-minimal.temurin-21-jdk.version>
+        <ubi9.temurin-21-jdk.version>21.0.11.0.0.10-0</ubi9.temurin-21-jdk.version>
 
         <!-- GitHub Repository Tags -->
         <git-repo.cp-docker-utils.tag>v1.0.16</git-repo.cp-docker-utils.tag>

--- a/pom.xml
+++ b/pom.xml
@@ -158,8 +158,8 @@
         <app.gid>1000</app.gid>
 
         <!-- Base Image Versions -->
-        <ubi9.image.version>9.7-1771346757</ubi9.image.version>
-        <ubi9-micro.image.version>9.7-1771346390</ubi9-micro.image.version>
+        <ubi9.image.version>9.8-1782121068</ubi9.image.version>
+        <ubi9-micro.image.version>9.8-1779858820</ubi9-micro.image.version>
 
         <!-- OS Package Versions -->
         <ubi9.temurin-21-jdk.version>21.0.11.0.0.10-0</ubi9.temurin-21-jdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,10 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <buildArgs>
-                        <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
-                        <ARCH>${arch.type}</ARCH>
+                        <APP_UID>${app.uid}</APP_UID>
+                        <APP_GID>${app.gid}</APP_GID>
+                        <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
+                        <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                         <GATEWAY_VERSION>${GATEWAY_VERSION}</GATEWAY_VERSION>
                         <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
                         <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
@@ -95,8 +97,10 @@
                         <image>
                             <build>
                                 <args>
-                                    <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
-                                    <ARCH>${arch.type}</ARCH>
+                                    <APP_UID>${app.uid}</APP_UID>
+                                    <APP_GID>${app.gid}</APP_GID>
+                                    <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
+                                    <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                                     <GATEWAY_VERSION>${GATEWAY_VERSION}</GATEWAY_VERSION>
                                     <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
                                     <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
@@ -148,8 +152,13 @@
         the automation tooling can correctly identify and update them.
         -->
 
+        <!-- App User/Group IDs - can be overridden at build time via -Dapp.uid=<value> -Dapp.gid=<value> -->
+        <app.uid>1000</app.uid>
+        <app.gid>1000</app.gid>
+
         <!-- Base Image Versions -->
-        <ubi9-minimal.image.version>9.7-1776833838</ubi9-minimal.image.version>
+        <ubi9.image.version>9.7-1771346757</ubi9.image.version>
+        <ubi9-micro.image.version>9.7-1771346390</ubi9-micro.image.version>
 
         <!-- OS Package Versions -->
         <ubi9-minimal.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9-minimal.temurin-21-jdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,6 @@
                                     <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
                                     <TEMURIN_JDK_VERSION>-${ubi9.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
                                     <SHADOW_UTILS_VERSION>-${ubi9.shadow-utils.version}</SHADOW_UTILS_VERSION>
-                                    <SED_VERSION>-${ubi9.sed.version}</SED_VERSION>
                                     <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                                 </args>
                             </build>
@@ -166,7 +165,6 @@
         <!-- OS Package Versions -->
         <ubi9.temurin-21-jdk.version>21.0.11.0.0.10-0</ubi9.temurin-21-jdk.version>
         <ubi9.shadow-utils.version>4.9-16.el9</ubi9.shadow-utils.version>
-        <ubi9.sed.version>4.8-10.el9</ubi9.sed.version>
 
         <!-- GitHub Repository Tags -->
         <git-repo.cp-docker-utils.tag>v1.0.16</git-repo.cp-docker-utils.tag>


### PR DESCRIPTION
## Summary

PR changes for ubi9 micro migration for gateway docker images

## Local Redhat Certification
Ran redhat certification on latest commit images: https://semaphore.ci.confluent.io/workflows/d8000d0f-ef64-4f5b-b616-58dcec9435d1?pipeline_id=3bdf18b1-fc5a-46c2-8043-0fc54c9abea5


## Test plan

- [x] **CI build passes** — Semaphore green ✅
- [x] **SonarQube quality gate** ✅
- [x] RedHat certification pipeline passes for both images - https://semaphore.ci.confluent.io/workflows/d8000d0f-ef64-4f5b-b616-58dcec9435d1?pipeline_id=3bdf18b1-fc5a-46c2-8043-0fc54c9abea5
- [x]  Version-compat sign-off (per @hrishabhg scope): ubi9-micro gateway RC dev-1.3.x-9cac10ba-ubi9.amd64 passes --single client 8.0.0 × cp-server 8.0.0 (KRaft) — PLAINTEXT/SASL/SSL all 14/14, 0 failures, broker
  healthy (Total:1 Passed:1 Failed:0): https://semaphore.ci.confluent.io/workflows/48f1771e-dc76-4ae7-8a2d-a52c8988328c
