### PR TITLE
Add governance example: per-topic schema validation levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ compatibility-results/
 __pycache__/
 .venv/
 venv/
+
+# Local Confluent license for the governance example
+examples/governance/.env

--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -1,0 +1,133 @@
+# CPC Gateway — Schema Usage Enforcement
+
+This example demonstrates **schema usage enforcement** with CPC Gateway. The Gateway validates that all records produced to Kafka use a schema registered in Confluent Schema Registry. Records without a valid schema ID are rejected before reaching the broker.
+
+Platform operators configure enforcement once at the Gateway — all producer traffic is validated automatically with zero client changes.
+
+## How It Works
+
+```
+┌──────────┐        ┌───────────────────┐        ┌───────────────┐
+│ Producer │───────>│    CPC Gateway    │───────>│  Confluent    │
+│          │        │     :6969         │        │  Server       │
+│ Consumer │<───── │                   │<───── │  :29092       │
+└──────────┘        └────────┬──────────┘        └───────────────┘
+                             │
+                   schema ID lookup
+                             │
+                    ┌────────▼──────────┐
+                    │  Schema Registry  │
+                    │     :8081         │
+                    └───────────────────┘
+```
+
+- **Producers** connect to the Gateway (port 6969) instead of the broker directly
+- **Gateway** checks that the schema ID in each record is registered in Schema Registry
+- Records with a valid schema ID pass through; records without one are rejected with `INVALID_RECORD`
+
+## Prerequisites
+
+- Docker and Docker Compose
+- [kcat](https://github.com/edenhill/kcat) (for negative test)
+- Access to the CPC Gateway Docker image (internal ECR)
+- A valid **Confluent Private Cloud license** — all three components (Confluent Server, Schema Registry, and CPC Gateway) require a CPC license to run
+
+## Quick Start
+
+### 1. Set your license
+
+```bash
+export CONFLUENT_LICENSE='<your-enterprise-license-jwt>'
+```
+
+### 2. Start the stack
+
+```bash
+docker compose up -d
+```
+
+This starts three containers:
+- `kafka` — Confluent Server (KRaft mode, single node)
+- `schema-registry` — Confluent Schema Registry
+- `gateway` — CPC Gateway with schema usage enforcement enabled
+
+### 3. Register a schema
+
+```bash
+./scripts/register-schemas.sh
+```
+
+This registers an Avro schema for `Order` records under the subject `orders-value`.
+
+### 4. Run the demo
+
+#### Positive test — produce with a valid schema ID (accepted)
+
+```bash
+docker exec -it schema-registry kafka-avro-console-producer \
+  --broker-list gateway:6969 \
+  --topic orders \
+  --property schema.registry.url=http://schema-registry:8081 \
+  --property value.schema.id=1 \
+  --producer-property security.protocol=SASL_PLAINTEXT \
+  --producer-property sasl.mechanism=PLAIN \
+  --producer-property sasl.jaas.config='org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";'
+```
+
+Type the following and press Enter:
+```json
+{"order_id":"ORD-001","product":"laptop","quantity":1,"price":999.99}
+```
+
+The record is accepted — Gateway validated that schema ID 1 is registered under `orders-value`.
+
+#### Negative test — produce without a valid schema ID (rejected)
+
+```bash
+printf '\x00\x00\x00\x03\xe7hello' | kcat -b localhost:6969 -t orders -P \
+  -X security.protocol=SASL_PLAINTEXT \
+  -X sasl.mechanism=PLAIN \
+  -X sasl.username=admin \
+  -X sasl.password=admin-secret
+```
+
+This sends a record with schema ID 999 (unregistered). Gateway rejects it — the schema ID is not found in Schema Registry.
+
+#### Verify — consume to see only the valid record
+
+```bash
+docker exec schema-registry kafka-avro-console-consumer \
+  --bootstrap-server gateway:6969 \
+  --topic orders \
+  --from-beginning \
+  --property schema.registry.url=http://schema-registry:8081 \
+  --consumer-property security.protocol=SASL_PLAINTEXT \
+  --consumer-property sasl.mechanism=PLAIN \
+  --consumer-property sasl.jaas.config='org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";'
+```
+
+Only the valid order record appears — the rejected record never reached the broker.
+
+## Gateway Configuration
+
+```yaml
+gateway:
+  schemaValidation:
+    schemaRegistryUrls:
+      - "http://schema-registry:8081"
+    keyValidationLevel: NONE
+    valueValidationLevel: ID
+    valueSubjectNameStrategy: TOPIC
+```
+
+| Setting | Value | Description |
+|---|---|---|
+| `valueValidationLevel` | `ID` | Validate that the schema ID in each record is registered in Schema Registry |
+| `keyValidationLevel` | `NONE` | No validation on record keys |
+| `valueSubjectNameStrategy` | `TOPIC` | Schema subject is `{topic}-value` |
+
+## Cleanup
+
+```bash
+docker compose down -v
+```

--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -1,6 +1,6 @@
 # CPC Gateway — Schema Usage Enforcement
 
-This example demonstrates **schema usage enforcement** with CPC Gateway. The Gateway validates that all records produced to Kafka use a schema registered in Confluent Schema Registry. Records without a valid schema ID are rejected before reaching the broker.
+This example demonstrates **schema ID enforcement** with CPC Gateway. The Gateway validates that all records produced to Kafka use a schema registered in Confluent Schema Registry. Records without a valid schema ID are rejected before reaching the broker.
 
 Platform operators configure enforcement once at the Gateway — all producer traffic is validated automatically with zero client changes.
 
@@ -49,7 +49,7 @@ docker compose up -d
 This starts three containers:
 - `kafka` — Confluent Server (KRaft mode, single node)
 - `schema-registry` — Confluent Schema Registry
-- `gateway` — CPC Gateway with schema usage enforcement enabled
+- `gateway` — CPC Gateway with schema ID enforcement enabled
 
 ### 3. Register a schema
 

--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -1,19 +1,19 @@
-# CPC Gateway — Schema Usage Enforcement
+# CPC Gateway — Schema Governance
 
-This example demonstrates **schema ID enforcement** with CPC Gateway. The Gateway validates that all records produced to Kafka use a schema registered in Confluent Schema Registry. Records without a valid schema ID are rejected before reaching the broker.
+This example demonstrates **schema governance** with CPC Gateway. The Gateway validates that records produced to Kafka conform to schemas registered in Confluent Schema Registry — enforced centrally at the Gateway, with **zero client changes**. Records that violate the configured policy are rejected before they reach the broker.
 
-Platform operators configure enforcement once at the Gateway — all producer traffic is validated automatically with zero client changes.
+The example shows the **four validation levels** (`NONE`, `ID`, `SCHEMA`, `SCHEMA_RULES`) side by side, each applied to a different topic on the same route.
 
 ## How It Works
 
 ```
 ┌──────────┐        ┌───────────────────┐        ┌───────────────┐
-│ Producer │───────>│    CPC Gateway    │───────>│  Confluent    │
+│ Producer │───────▶│    CPC Gateway    │───────▶│  Confluent    │
 │          │        │     :6969         │        │  Server       │
-│ Consumer │<───── │                   │<───── │  :29092       │
+│ Consumer │◀────── │                   │◀────── │  :29092       │
 └──────────┘        └────────┬──────────┘        └───────────────┘
                              │
-                   schema ID lookup
+                   schema / ID lookup
                              │
                     ┌────────▼──────────┐
                     │  Schema Registry  │
@@ -21,23 +21,32 @@ Platform operators configure enforcement once at the Gateway — all producer tr
                     └───────────────────┘
 ```
 
-- **Producers** connect to the Gateway (port 6969) instead of the broker directly
-- **Gateway** checks that the schema ID in each record is registered in Schema Registry
-- Records with a valid schema ID pass through; records without one are rejected with `INVALID_RECORD`
+- **Producers** connect to the Gateway (port 6969) instead of the broker directly.
+- The **Gateway** inspects each record's value against the validation level configured for that topic.
+- Conforming records pass through; violations are rejected with `INVALID_RECORD`.
+
+> **Note:** Enforcement reads the schema ID from the Confluent **wire-format prefix** (`[0x00][4-byte schema ID]`) inside the record. A producer using a **Confluent serializer** (e.g. `KafkaAvroSerializer`) emits this prefix. A **non-Confluent serializer** (plain `StringSerializer`, raw bytes) does not, so the Gateway can only reject it on a presence check — it cannot validate or transcode it.
 
 ## Prerequisites
 
 - Docker and Docker Compose
-- [kcat](https://github.com/edenhill/kcat) (for negative test)
 - Access to the CPC Gateway Docker image (internal ECR)
-- A valid **Confluent Private Cloud license** — all three components (Confluent Server, Schema Registry, and CPC Gateway) require a CPC license to run
+- A valid **Confluent license JWT** — all three components (Confluent Server, Schema Registry, CPC Gateway) require a license to run. The `SCHEMA_RULES` / encryption scenarios additionally require the **CSFLE add-on** on the license.
 
 ## Quick Start
 
 ### 1. Set your license
 
+The compose file reads `CONFLUENT_LICENSE`. Either export it in your shell:
+
 ```bash
-export CONFLUENT_LICENSE='<your-enterprise-license-jwt>'
+export CONFLUENT_LICENSE='<your-license-jwt>'
+```
+
+…or create a `.env` file in this directory (auto-read by Docker Compose, and gitignored):
+
+```bash
+echo "CONFLUENT_LICENSE=<your-license-jwt>" > .env
 ```
 
 ### 2. Start the stack
@@ -47,96 +56,143 @@ docker compose up -d
 ```
 
 This starts three containers:
-- `kafka` — Confluent Server (KRaft mode, single node)
+- `kafka` — Confluent Server (KRaft mode, single node), SASL/PLAIN auth
 - `schema-registry` — Confluent Schema Registry
-- `gateway` — CPC Gateway with schema ID enforcement enabled
+- `gateway` — CPC Gateway with schema governance enabled
 
-### 3. Register a schema
+### 3. Register the schemas
 
 ```bash
 ./scripts/register-schemas.sh
 ```
 
-This registers an Avro schema for `Order` records under the subject `orders-value`.
+## What Gets Created
 
-### 4. Run the demo
+### Schemas and subjects
 
-#### Positive test — produce with a valid schema ID (accepted)
+The registration script creates **two distinct schemas**. Schema IDs are **global and content-deduplicated** — the same `Order` schema reused under three subjects keeps the same ID (`1`):
+
+| Schema ID | Schema | Fields | Registered under subjects |
+|---|---|---|---|
+| **1** | `Order` | `order_id, product, quantity, price` | `orders-value`, `gov-id-value`, `gov-schema-value` |
+| **2** | `Event` | `event_id, kind` | `events-value` |
+
+> **Schemas vs subjects vs IDs:** the **ID** identifies a unique schema globally; the **subject** (`<topic>-value` under the `TOPIC` strategy) is the per-topic slot it's registered under. The wire-format prefix carries the **ID**; the Gateway derives the expected **subject** from the topic and checks that the ID is registered *under that subject*.
+
+### Topics and their validation levels
+
+Topics are auto-created on first produce. Each is pinned to a validation level via per-topic overrides in `gateway.yaml`:
+
+| Topic | Validation level | Expected value subject | Conforming schema |
+|---|---|---|---|
+| `gov-none`   | `NONE`         | — | anything (no checks) |
+| `gov-id`     | `ID`           | `gov-id-value`     | `Order` (id 1) |
+| `gov-schema` | `SCHEMA`       | `gov-schema-value` | `Order` (id 1) |
+| `gov-rules`  | `SCHEMA_RULES` | `gov-rules-value`  | data-contract rules (incl. field-level encryption) |
+
+### What each validation level enforces
+
+| Level | Enforces |
+|---|---|
+| `NONE` | Nothing — all records accepted. |
+| `ID` | Value must carry a valid wire-format schema ID **and** that ID must be registered under the topic's subject. Does **not** inspect payload content. |
+| `SCHEMA` | Everything `ID` checks **plus** the payload must successfully deserialize against the schema. |
+| `SCHEMA_RULES` | Everything `SCHEMA` checks **plus** the schema's data-contract rules execute (e.g. CSFLE field-level encryption). |
+
+> **Tip:** keys and values are governed independently. This example sets `keyValidationLevel: NONE` (keys ungoverned) and overrides `valueValidationLevel` per topic. To govern keys, register a `<topic>-key` subject and raise `keyValidationLevel`.
+
+## Running the Tests
+
+The `kafka` container has the plain console tools (`kafka-console-producer/consumer`); the `schema-registry` container has the Avro tools (`kafka-avro-console-producer/consumer`). The SASL JAAS string is reused below as `$JAAS`:
 
 ```bash
-docker exec -it schema-registry kafka-avro-console-producer \
-  --broker-list gateway:6969 \
-  --topic orders \
+JAAS='org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";'
+```
+
+### Test 1 — Valid record with a Confluent serializer (accepted)
+
+```bash
+echo '{"order_id":"O1","product":"widget","quantity":2,"price":9.99}' | \
+docker exec -i schema-registry kafka-avro-console-producer \
+  --broker-list gateway:6969 --topic gov-schema \
   --property schema.registry.url=http://schema-registry:8081 \
   --property value.schema.id=1 \
   --producer-property security.protocol=SASL_PLAINTEXT \
   --producer-property sasl.mechanism=PLAIN \
-  --producer-property sasl.jaas.config='org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";'
+  --producer-property sasl.jaas.config="$JAAS"
 ```
+**Accepted** — id 1 is registered under `gov-schema-value` and the payload conforms to `Order`.
 
-Type the following and press Enter:
-```json
-{"order_id":"ORD-001","product":"laptop","quantity":1,"price":999.99}
-```
-
-The record is accepted — Gateway validated that schema ID 1 is registered under `orders-value`.
-
-#### Negative test — produce without a valid schema ID (rejected)
+### Test 2 — Non-Confluent client, plain text with no schema ID (rejected)
 
 ```bash
-printf '\x00\x00\x00\x03\xe7hello' | kcat -b localhost:6969 -t orders -P \
-  -X security.protocol=SASL_PLAINTEXT \
-  -X sasl.mechanism=PLAIN \
-  -X sasl.username=admin \
-  -X sasl.password=admin-secret
+echo "plain-text-no-schema-id" | \
+docker exec -i kafka kafka-console-producer \
+  --broker-list gateway:6969 --topic gov-id \
+  --producer-property security.protocol=SASL_PLAINTEXT \
+  --producer-property sasl.mechanism=PLAIN \
+  --producer-property sasl.jaas.config="$JAAS"
 ```
+**Rejected** at `ID` — `InvalidRecordException: Error deserializing schema ID` (no wire-format prefix). The same record sent to `gov-none` is **accepted** (no checks).
 
-This sends a record with schema ID 999 (unregistered). Gateway rejects it — the schema ID is not found in Schema Registry.
+### Test 3 — Confluent serializer, wrong subject (rejected)
 
-#### Non-Confluent client — plain JSON without wire format (rejected)
-
-Gateway enforcement is byte-level, not library-level. A client that doesn't use the Confluent serializer can still be rejected if it omits the wire-format prefix:
+Produce an `Event` record (id 2, registered only under `events-value`) to a topic governed for `Order`. `auto.register.schemas=false` keeps the client from registering; the Gateway judges the subject:
 
 ```bash
-printf '{"order_id":"ORD-999","product":"plain-json","quantity":1,"price":1.0}' \
-  | kcat -b localhost:6969 -t orders -P \
-    -X security.protocol=SASL_PLAINTEXT \
-    -X sasl.mechanism=PLAIN \
-    -X sasl.username=admin \
-    -X sasl.password=admin-secret
-```
-
-Gateway rejects: the first byte is not `0x00`, so there is no schema ID to validate.
-
-#### Non-Confluent client — wire format with a valid schema ID but bogus payload (rejected)
-
-The `orders` topic is configured with `valueValidationLevel: SCHEMA` (see Gateway Configuration below), so the gateway deserializes each record against the registered schema. A non-Confluent client can fake the wire format prefix with a registered schema ID, but if the payload bytes don't decode as valid Avro for that schema the record is rejected:
-
-```bash
-printf '\x00\x00\x00\x00\x01bogus-payload-not-real-avro' \
-  | kcat -b localhost:6969 -t orders -P \
-    -X security.protocol=SASL_PLAINTEXT \
-    -X sasl.mechanism=PLAIN \
-    -X sasl.username=admin \
-    -X sasl.password=admin-secret
-```
-
-Gateway rejects: `KafkaAvroDeserializer` fails to decode the payload against the `Order` schema. Under `valueValidationLevel: ID` this same record would have been accepted — `SCHEMA` mode adds payload validation on top of the schema ID check.
-
-#### Verify — consume to see only the valid record
-
-```bash
-docker exec schema-registry kafka-avro-console-consumer \
-  --bootstrap-server gateway:6969 \
-  --topic orders \
-  --from-beginning \
+echo '{"event_id":"E1","kind":"click"}' | \
+docker exec -i schema-registry kafka-avro-console-producer \
+  --broker-list gateway:6969 --topic gov-schema \
   --property schema.registry.url=http://schema-registry:8081 \
+  --property auto.register.schemas=false --property use.schema.id=2 --property value.schema.id=2 \
+  --producer-property security.protocol=SASL_PLAINTEXT \
+  --producer-property sasl.mechanism=PLAIN \
+  --producer-property sasl.jaas.config="$JAAS"
+```
+**Rejected** — `Failed to get schema for topic=gov-schema ... schemaId=id=2`. The ID exists globally but not under `gov-schema-value`. (Rejected at `ID` too — the subject check happens at `ID` and above.)
+
+### Test 4 — Valid schema ID, malformed payload (the ID vs SCHEMA difference)
+
+The same bytes — a valid id=1 prefix followed by non-Avro garbage — behave differently per level:
+
+```bash
+# At ID level: ACCEPTED (payload not inspected)
+docker exec -i kafka bash -c "printf '\x00\x00\x00\x00\x01GARBAGE' | \
+  kafka-console-producer --broker-list gateway:6969 --topic gov-id \
+  --producer-property security.protocol=SASL_PLAINTEXT \
+  --producer-property sasl.mechanism=PLAIN \
+  --producer-property sasl.jaas.config='$JAAS'"
+
+# At SCHEMA level: REJECTED — "Error deserializing Avro message ... id=1"
+docker exec -i kafka bash -c "printf '\x00\x00\x00\x00\x01GARBAGE' | \
+  kafka-console-producer --broker-list gateway:6969 --topic gov-schema \
+  --producer-property security.protocol=SASL_PLAINTEXT \
+  --producer-property sasl.mechanism=PLAIN \
+  --producer-property sasl.jaas.config='$JAAS'"
+```
+This is the one test that distinguishes `ID` from `SCHEMA`: `ID` only checks the schema ID resolves; `SCHEMA` also deserializes the payload.
+
+### Verify — consume to confirm what landed
+
+```bash
+docker exec kafka kafka-console-consumer \
+  --bootstrap-server gateway:6969 --topic gov-none --from-beginning \
   --consumer-property security.protocol=SASL_PLAINTEXT \
   --consumer-property sasl.mechanism=PLAIN \
-  --consumer-property sasl.jaas.config='org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";'
+  --consumer-property sasl.jaas.config="$JAAS"
 ```
+Only accepted records appear — rejected records never reached the broker.
 
-Only the valid order record appears — the rejected record never reached the broker.
+## Results Summary
+
+| Test | Topic (level) | Payload | Result |
+|---|---|---|---|
+| 1 | `gov-schema` (SCHEMA) | `Order` id=1, conforming | accepted |
+| 2 | `gov-id` (ID) | plain text, no prefix | rejected (`Error deserializing schema ID`) |
+| 2 | `gov-none` (NONE) | plain text, no prefix | accepted |
+| 3 | `gov-schema` (SCHEMA) | `Event` id=2 (wrong subject) | rejected (`Failed to get schema ... id=2`) |
+| 4 | `gov-id` (ID) | id=1 prefix + garbage | accepted |
+| 4 | `gov-schema` (SCHEMA) | id=1 prefix + garbage | rejected (`Error deserializing Avro message`) |
 
 ## Gateway Configuration
 
@@ -146,28 +202,25 @@ gateway:
     schemaRegistryUrls:
       - "http://schema-registry:8081"
     keyValidationLevel: NONE
-    valueValidationLevel: ID            # default for all topics
-    valueSubjectNameStrategy: TOPIC
+    valueValidationLevel: ID          # default for any topic not listed below
+    valueSubjectNameStrategy: TOPIC   # subject = {topic}-value
     topics:
-      - name: orders
-        valueValidationLevel: SCHEMA    # stricter for orders only
+      - name: gov-none
+        valueValidationLevel: NONE
+      - name: gov-id
+        valueValidationLevel: ID
+      - name: gov-schema
+        valueValidationLevel: SCHEMA
+      - name: gov-rules
+        valueValidationLevel: SCHEMA_RULES
 ```
 
 | Setting | Value | Description |
 |---|---|---|
-| `valueValidationLevel` (default) | `ID` | Validate that the schema ID in each record is registered in Schema Registry |
-| `valueValidationLevel` (orders) | `SCHEMA` | `ID` + deserialize the payload against the schema |
+| `valueValidationLevel` | `ID` | Default level for topics without an override |
 | `keyValidationLevel` | `NONE` | No validation on record keys |
-| `valueSubjectNameStrategy` | `TOPIC` | Schema subject is `{topic}-value` |
-
-### Validation levels
-
-| Level | What it checks |
-|---|---|
-| `NONE` | Nothing |
-| `ID` | Schema ID exists in Schema Registry under the correct subject |
-| `SCHEMA` | `ID` + payload deserializes against the schema |
-| `DATA_CONTRACT` | `SCHEMA` + Schema Registry rules (encryption, data quality) executed |
+| `valueSubjectNameStrategy` | `TOPIC` | Value subject is `{topic}-value` |
+| `topics[]` | per-topic | Override key/value validation level for a specific topic |
 
 ## Cleanup
 

--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -93,6 +93,36 @@ printf '\x00\x00\x00\x03\xe7hello' | kcat -b localhost:6969 -t orders -P \
 
 This sends a record with schema ID 999 (unregistered). Gateway rejects it — the schema ID is not found in Schema Registry.
 
+#### Non-Confluent client — plain JSON without wire format (rejected)
+
+Gateway enforcement is byte-level, not library-level. A client that doesn't use the Confluent serializer can still be rejected if it omits the wire-format prefix:
+
+```bash
+printf '{"order_id":"ORD-999","product":"plain-json","quantity":1,"price":1.0}' \
+  | kcat -b localhost:6969 -t orders -P \
+    -X security.protocol=SASL_PLAINTEXT \
+    -X sasl.mechanism=PLAIN \
+    -X sasl.username=admin \
+    -X sasl.password=admin-secret
+```
+
+Gateway rejects: the first byte is not `0x00`, so there is no schema ID to validate.
+
+#### Non-Confluent client — wire format with a valid schema ID (accepted)
+
+Any client that emits the Confluent wire format (`0x00` magic byte + 4-byte schema ID) with a registered ID is accepted — no Confluent serializer required:
+
+```bash
+printf '\x00\x00\x00\x00\x01bogus-payload-not-real-avro' \
+  | kcat -b localhost:6969 -t orders -P \
+    -X security.protocol=SASL_PLAINTEXT \
+    -X sasl.mechanism=PLAIN \
+    -X sasl.username=admin \
+    -X sasl.password=admin-secret
+```
+
+Gateway accepts: schema ID 1 is registered. Note that `valueValidationLevel: ID` validates the schema ID exists in Schema Registry — it does not validate that the payload bytes conform to the schema.
+
 #### Verify — consume to see only the valid record
 
 ```bash

--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -33,18 +33,20 @@ The example shows the **four validation levels** (`NONE`, `ID`, `SCHEMA`, `SCHEM
 
 ## Quick Start
 
-### 1. Set your license
+### 1. Set your license and Gateway image
 
-The compose file reads `CONFLUENT_LICENSE`. Either export it in your shell:
+The compose file reads two variables: `CONFLUENT_LICENSE` (the license JWT) and `GATEWAY_IMAGE` (the CPC Gateway image tag or digest to run). Either export them in your shell:
 
 ```bash
 export CONFLUENT_LICENSE='<your-license-jwt>'
+export GATEWAY_IMAGE='<cpc-gateway-image:tag>'
 ```
 
 …or create a `.env` file in this directory (auto-read by Docker Compose, and gitignored):
 
 ```bash
 echo "CONFLUENT_LICENSE=<your-license-jwt>" > .env
+echo "GATEWAY_IMAGE=<cpc-gateway-image:tag>" >> .env
 ```
 
 ### 2. Start the stack

--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -1,6 +1,6 @@
-# CPC Gateway — Schema Governance
+# Centralised Governance Policy Enforcement with CPC Gateway
 
-This example demonstrates **schema governance** with CPC Gateway. The Gateway validates that records produced to Kafka conform to schemas registered in Confluent Schema Registry — enforced centrally at the Gateway, with **zero client changes**. Records that violate the configured policy are rejected before they reach the broker.
+This example demonstrates **centralised data governance enforcement** with CPC Gateway. The Gateway validates that records produced to Kafka conform to schemas registered in Confluent Schema Registry — enforced centrally at the Gateway, with **zero client changes**. Records that violate the configured policy are rejected before they reach the broker.
 
 The example shows the **four validation levels** (`NONE`, `ID`, `SCHEMA`, `SCHEMA_RULES`) side by side, each applied to a different topic on the same route.
 
@@ -25,12 +25,10 @@ The example shows the **four validation levels** (`NONE`, `ID`, `SCHEMA`, `SCHEM
 - The **Gateway** inspects each record's value against the validation level configured for that topic.
 - Conforming records pass through; violations are rejected with `INVALID_RECORD`.
 
-> **Note:** Enforcement reads the schema ID from the Confluent **wire-format prefix** (`[0x00][4-byte schema ID]`) inside the record. A producer using a **Confluent serializer** (e.g. `KafkaAvroSerializer`) emits this prefix. A **non-Confluent serializer** (plain `StringSerializer`, raw bytes) does not, so the Gateway can only reject it on a presence check — it cannot validate or transcode it.
-
 ## Prerequisites
 
 - Docker and Docker Compose
-- Access to the CPC Gateway Docker image (internal ECR)
+- Access to the CPC Gateway Docker image
 - A valid **Confluent license JWT** — all three components (Confluent Server, Schema Registry, CPC Gateway) require a license to run. The `SCHEMA_RULES` / encryption scenarios additionally require the **CSFLE add-on** on the license.
 
 ## Quick Start
@@ -70,14 +68,12 @@ This starts three containers:
 
 ### Schemas and subjects
 
-The registration script creates **two distinct schemas**. Schema IDs are **global and content-deduplicated** — the same `Order` schema reused under three subjects keeps the same ID (`1`):
+The registration script creates **two distinct schemas**:
 
 | Schema ID | Schema | Fields | Registered under subjects |
 |---|---|---|---|
 | **1** | `Order` | `order_id, product, quantity, price` | `orders-value`, `gov-id-value`, `gov-schema-value` |
 | **2** | `Event` | `event_id, kind` | `events-value` |
-
-> **Schemas vs subjects vs IDs:** the **ID** identifies a unique schema globally; the **subject** (`<topic>-value` under the `TOPIC` strategy) is the per-topic slot it's registered under. The wire-format prefix carries the **ID**; the Gateway derives the expected **subject** from the topic and checks that the ID is registered *under that subject*.
 
 ### Topics and their validation levels
 

--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -108,9 +108,9 @@ printf '{"order_id":"ORD-999","product":"plain-json","quantity":1,"price":1.0}' 
 
 Gateway rejects: the first byte is not `0x00`, so there is no schema ID to validate.
 
-#### Non-Confluent client — wire format with a valid schema ID (accepted)
+#### Non-Confluent client — wire format with a valid schema ID but bogus payload (rejected)
 
-Any client that emits the Confluent wire format (`0x00` magic byte + 4-byte schema ID) with a registered ID is accepted — no Confluent serializer required:
+The `orders` topic is configured with `valueValidationLevel: SCHEMA` (see Gateway Configuration below), so the gateway deserializes each record against the registered schema. A non-Confluent client can fake the wire format prefix with a registered schema ID, but if the payload bytes don't decode as valid Avro for that schema the record is rejected:
 
 ```bash
 printf '\x00\x00\x00\x00\x01bogus-payload-not-real-avro' \
@@ -121,7 +121,7 @@ printf '\x00\x00\x00\x00\x01bogus-payload-not-real-avro' \
     -X sasl.password=admin-secret
 ```
 
-Gateway accepts: schema ID 1 is registered. Note that `valueValidationLevel: ID` validates the schema ID exists in Schema Registry — it does not validate that the payload bytes conform to the schema.
+Gateway rejects: `KafkaAvroDeserializer` fails to decode the payload against the `Order` schema. Under `valueValidationLevel: ID` this same record would have been accepted — `SCHEMA` mode adds payload validation on top of the schema ID check.
 
 #### Verify — consume to see only the valid record
 
@@ -146,15 +146,28 @@ gateway:
     schemaRegistryUrls:
       - "http://schema-registry:8081"
     keyValidationLevel: NONE
-    valueValidationLevel: ID
+    valueValidationLevel: ID            # default for all topics
     valueSubjectNameStrategy: TOPIC
+    topics:
+      - name: orders
+        valueValidationLevel: SCHEMA    # stricter for orders only
 ```
 
 | Setting | Value | Description |
 |---|---|---|
-| `valueValidationLevel` | `ID` | Validate that the schema ID in each record is registered in Schema Registry |
+| `valueValidationLevel` (default) | `ID` | Validate that the schema ID in each record is registered in Schema Registry |
+| `valueValidationLevel` (orders) | `SCHEMA` | `ID` + deserialize the payload against the schema |
 | `keyValidationLevel` | `NONE` | No validation on record keys |
 | `valueSubjectNameStrategy` | `TOPIC` | Schema subject is `{topic}-value` |
+
+### Validation levels
+
+| Level | What it checks |
+|---|---|
+| `NONE` | Nothing |
+| `ID` | Schema ID exists in Schema Registry under the correct subject |
+| `SCHEMA` | `ID` + payload deserializes against the schema |
+| `DATA_CONTRACT` | `SCHEMA` + Schema Registry rules (encryption, data quality) executed |
 
 ## Cleanup
 

--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -93,7 +93,7 @@ Topics are auto-created on first produce. Each is pinned to a validation level v
 | `NONE` | Nothing — all records accepted. |
 | `ID` | Value must carry a valid wire-format schema ID **and** that ID must be registered under the topic's subject. Does **not** inspect payload content. |
 | `SCHEMA` | Everything `ID` checks **plus** the payload must successfully deserialize against the schema. |
-| `SCHEMA_RULES` | Everything `SCHEMA` checks **plus** the schema's data-contract rules execute (e.g. CSFLE field-level encryption). |
+| `SCHEMA_RULES` | `SCHEMA` + Schema Registry rules (encryption, data quality) executed |
 
 > **Tip:** keys and values are governed independently. This example sets `keyValidationLevel: NONE` (keys ungoverned) and overrides `valueValidationLevel` per topic. To govern keys, register a `<topic>-key` subject and raise `keyValidationLevel`.
 

--- a/examples/governance/docker-compose.yaml
+++ b/examples/governance/docker-compose.yaml
@@ -1,0 +1,80 @@
+services:
+
+  kafka:
+    image: confluentinc/cp-server:7.9.0
+    container_name: kafka
+    networks:
+      - gateway-network
+    ports:
+      - "9092:9092"
+    volumes:
+      - ./kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:9093'
+      CLUSTER_ID: '4L6g3nShT-eMCtK--X86sw'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'INTERNAL:SASL_PLAINTEXT,EXTERNAL:SASL_PLAINTEXT,CONTROLLER:PLAINTEXT'
+      KAFKA_LISTENERS: 'INTERNAL://kafka:29092,EXTERNAL://0.0.0.0:9092,CONTROLLER://kafka:9093'
+      KAFKA_ADVERTISED_LISTENERS: 'INTERNAL://kafka:29092,EXTERNAL://localhost:9092'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'INTERNAL'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_METADATA_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_COMMAND_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_METRICS_REPORTER_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_LICENSE: ${CONFLUENT_LICENSE:?Set CONFLUENT_LICENSE env var with a valid Enterprise license JWT}
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.9.0
+    container_name: schema-registry
+    networks:
+      - gateway-network
+    depends_on:
+      - kafka
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'SASL_PLAINTEXT://kafka:29092'
+      SCHEMA_REGISTRY_KAFKASTORE_SASL_MECHANISM: 'PLAIN'
+      SCHEMA_REGISTRY_KAFKASTORE_SASL_JAAS_CONFIG: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";'
+      SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL: 'SASL_PLAINTEXT'
+      SCHEMA_REGISTRY_LISTENERS: 'http://0.0.0.0:8081'
+      SCHEMA_REGISTRY_SCHEMA_REGISTRY_GROUP_ID: 'schema-registry'
+      SCHEMA_REGISTRY_CONFLUENT_LICENSE: ${CONFLUENT_LICENSE:?Set CONFLUENT_LICENSE env var with a valid Enterprise license JWT}
+
+  gateway:
+    image: 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/confluentinc/cpc-gateway:master-latest-ubi9
+    container_name: gateway
+    networks:
+      - gateway-network
+    depends_on:
+      - kafka
+      - schema-registry
+    volumes:
+      - ./gateway.yaml:/etc/gateway/config.yaml
+    environment:
+      GATEWAY_CONFIG_FILE: /etc/gateway/config.yaml
+    ports:
+      - "6969:6969"
+      - "6970:6970"
+      - "6971:6971"
+      - "9190:9190"
+    command: |
+      bash -c "
+        chmod +x /etc/confluent/docker/run 2>/dev/null || true
+        exec /etc/confluent/docker/run
+      "
+
+networks:
+  gateway-network:
+    driver: bridge

--- a/examples/governance/docker-compose.yaml
+++ b/examples/governance/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
       SCHEMA_REGISTRY_CONFLUENT_LICENSE: ${CONFLUENT_LICENSE:?Set CONFLUENT_LICENSE env var with a valid Enterprise license JWT}
 
   gateway:
-    image: 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/confluentinc/cpc-gateway:master-latest-ubi9
+    image: ${GATEWAY_IMAGE:?Set GATEWAY_IMAGE env var to a CPC Gateway image tag or digest}
     container_name: gateway
     networks:
       - gateway-network

--- a/examples/governance/gateway.yaml
+++ b/examples/governance/gateway.yaml
@@ -1,0 +1,37 @@
+gateway:
+  name: governance-demo
+
+  admin:
+    endpoints:
+      metrics: true
+
+  schemaValidation:
+    schemaRegistryUrls:
+      - "http://schema-registry:8081"
+    keyValidationLevel: NONE
+    valueValidationLevel: ID
+    valueSubjectNameStrategy: TOPIC
+
+  streamingDomains:
+    - name: local-kafka
+      type: kafka
+      kafkaCluster:
+        name: kafka-cluster
+        nodeIdRanges:
+          - name: brokers
+            start: 1
+            end: 5
+        bootstrapServers:
+          - id: internal
+            endpoint: "kafka:29092"
+
+  routes:
+    - name: governance-route
+      endpoint: "gateway:6969"
+      brokerIdentificationStrategy:
+        type: port
+      streamingDomain:
+        name: local-kafka
+        bootstrapServerId: internal
+      security:
+        auth: passthrough

--- a/examples/governance/gateway.yaml
+++ b/examples/governance/gateway.yaml
@@ -11,6 +11,9 @@ gateway:
     keyValidationLevel: NONE
     valueValidationLevel: ID
     valueSubjectNameStrategy: TOPIC
+    topics:
+      - name: orders
+        valueValidationLevel: SCHEMA
 
   streamingDomains:
     - name: local-kafka

--- a/examples/governance/gateway.yaml
+++ b/examples/governance/gateway.yaml
@@ -11,9 +11,16 @@ gateway:
     keyValidationLevel: NONE
     valueValidationLevel: ID
     valueSubjectNameStrategy: TOPIC
+    # Per-topic overrides demonstrate each validation level on the same route.
     topics:
-      - name: orders
+      - name: gov-none
+        valueValidationLevel: NONE
+      - name: gov-id
+        valueValidationLevel: ID
+      - name: gov-schema
         valueValidationLevel: SCHEMA
+      - name: gov-rules
+        valueValidationLevel: SCHEMA_RULES
 
   streamingDomains:
     - name: local-kafka

--- a/examples/governance/kafka_server_jaas.conf
+++ b/examples/governance/kafka_server_jaas.conf
@@ -1,0 +1,6 @@
+KafkaServer {
+    org.apache.kafka.common.security.plain.PlainLoginModule required
+    username="admin"
+    password="admin-secret"
+    user_admin="admin-secret";
+};

--- a/examples/governance/scripts/register-schemas.sh
+++ b/examples/governance/scripts/register-schemas.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Register schemas in Schema Registry for the governance demo.
+#
+# Usage: ./scripts/register-schemas.sh
+
+set -euo pipefail
+
+SR_URL="${SR_URL:-http://localhost:8081}"
+
+echo "==> Waiting for Schema Registry to be ready..."
+until curl -s "${SR_URL}/subjects" > /dev/null 2>&1; do
+  sleep 2
+done
+echo "    Schema Registry is ready."
+
+echo ""
+echo "==> Registering 'orders-value' schema (Avro)..."
+curl -s -X POST "${SR_URL}/subjects/orders-value/versions" \
+  -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+  -d '{
+    "schemaType": "AVRO",
+    "schema": "{\"type\":\"record\",\"name\":\"Order\",\"namespace\":\"io.confluent.demo\",\"fields\":[{\"name\":\"order_id\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"quantity\",\"type\":\"int\"},{\"name\":\"price\",\"type\":\"double\"}]}"
+  }' | python3 -m json.tool
+echo ""
+
+echo "==> Listing registered subjects:"
+curl -s "${SR_URL}/subjects" | python3 -m json.tool
+echo ""
+echo "Done. Schema registered successfully."

--- a/examples/governance/scripts/register-schemas.sh
+++ b/examples/governance/scripts/register-schemas.sh
@@ -2,28 +2,42 @@
 # Register schemas in Schema Registry for the governance demo.
 #
 # Usage: ./scripts/register-schemas.sh
+#
+# Registers:
+#   orders-value       Order  (Avro)  -> used by the default ID-level route
+#   events-value       Event  (Avro)  -> a *different* schema, used to demo
+#                                          wrong-subject rejection at SCHEMA level
+#   gov-id-value       Order          -> positive case for the ID-level topic
+#   gov-schema-value   Order          -> positive case for the SCHEMA-level topic
 
 set -euo pipefail
 
 SR_URL="${SR_URL:-http://localhost:8081}"
 
+ORDER_SCHEMA='{"type":"record","name":"Order","namespace":"io.confluent.demo","fields":[{"name":"order_id","type":"string"},{"name":"product","type":"string"},{"name":"quantity","type":"int"},{"name":"price","type":"double"}]}'
+EVENT_SCHEMA='{"type":"record","name":"Event","namespace":"io.confluent.demo","fields":[{"name":"event_id","type":"string"},{"name":"kind","type":"string"}]}'
+
+register() {
+  local subject="$1" schema="$2"
+  echo "==> Registering '${subject}'..."
+  curl -s -X POST "${SR_URL}/subjects/${subject}/versions" \
+    -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+    -d "{\"schemaType\":\"AVRO\",\"schema\":$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$schema")}" \
+    | python3 -m json.tool
+  echo ""
+}
+
 echo "==> Waiting for Schema Registry to be ready..."
-until curl -s "${SR_URL}/subjects" > /dev/null 2>&1; do
-  sleep 2
-done
+until curl -s "${SR_URL}/subjects" > /dev/null 2>&1; do sleep 2; done
 echo "    Schema Registry is ready."
-
-echo ""
-echo "==> Registering 'orders-value' schema (Avro)..."
-curl -s -X POST "${SR_URL}/subjects/orders-value/versions" \
-  -H "Content-Type: application/vnd.schemaregistry.v1+json" \
-  -d '{
-    "schemaType": "AVRO",
-    "schema": "{\"type\":\"record\",\"name\":\"Order\",\"namespace\":\"io.confluent.demo\",\"fields\":[{\"name\":\"order_id\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"quantity\",\"type\":\"int\"},{\"name\":\"price\",\"type\":\"double\"}]}"
-  }' | python3 -m json.tool
 echo ""
 
-echo "==> Listing registered subjects:"
+register "orders-value"     "$ORDER_SCHEMA"
+register "events-value"     "$EVENT_SCHEMA"
+register "gov-id-value"     "$ORDER_SCHEMA"
+register "gov-schema-value" "$ORDER_SCHEMA"
+
+echo "==> Registered subjects:"
 curl -s "${SR_URL}/subjects" | python3 -m json.tool
 echo ""
-echo "Done. Schema registered successfully."
+echo "Done."


### PR DESCRIPTION
## Summary
Adds `examples/governance/` — a self-contained Docker Compose stack (Confluent Server + Schema Registry + CPC Gateway) that demonstrates **per-topic schema validation levels** enforced at the Gateway, before records reach the broker.

The same Gateway route applies a different validation level per topic via `schemaValidation.topics[]` overrides:

| Topic | Level | Behavior |
|-------|-------|----------|
| `gov-none` | `NONE` | No validation — plaintext accepted |
| `gov-id` | `ID` | Record must carry a schema ID registered in SR; rejects records with no wire-format prefix and records whose subject doesn't match |
| `gov-schema` | `SCHEMA` | Everything `ID` does, **plus** the payload must conform to the registered schema (valid ID + garbage payload is rejected) |

Records that fail validation are rejected at the Gateway with `INVALID_RECORD` — they never reach Kafka.

## What's included
- `docker-compose.yaml` — Confluent Server + Schema Registry + CPC Gateway (license supplied via a gitignored `.env`)
- `gateway.yaml` — one route, per-topic validation-level overrides
- `scripts/register-schemas.sh` — registers the demo schemas (Order, Event)
- `README.md` — setup, the topic/level table, and copy-paste produce/consume tests for each level (both Confluent-serializer and non-Confluent-client cases)

## Test plan (verified end-to-end against the live stack)
- [x] `docker compose up -d` brings up all three containers (license via `.env`)
- [x] `./scripts/register-schemas.sh` registers the demo schemas
- [x] `gov-none`: plaintext produce accepted
- [x] `gov-id`: valid schema ID accepted; no-prefix and wrong-subject rejected
- [x] `gov-schema`: valid ID + non-conforming payload rejected; conforming payload accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)