### PR TITLE
CPBR-3687 | Update JDK version to JDK 25

### DIFF
--- a/confluent-gateway-for-cloud/Dockerfile.ubi9
+++ b/confluent-gateway-for-cloud/Dockerfile.ubi9
@@ -58,7 +58,7 @@ gpgcheck=1 \n\
 gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
 " > /etc/yum.repos.d/adoptium.repo \
     && echo "===> Installing Temurin JRE..." \
-    && microdnf install -y temurin-21-jre${TEMURIN_JDK_VERSION} \
+    && microdnf install -y temurin-25-jre${TEMURIN_JDK_VERSION} \
     && microdnf clean all \
     && echo "===> Creating appuser and directories..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \

--- a/gateway/Dockerfile.ubi9
+++ b/gateway/Dockerfile.ubi9
@@ -58,7 +58,7 @@ gpgcheck=1 \n\
 gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
 " > /etc/yum.repos.d/adoptium.repo \
     && echo "===> Installing Temurin JRE..." \
-    && microdnf install -y temurin-21-jre${TEMURIN_JDK_VERSION} \
+    && microdnf install -y temurin-25-jre${TEMURIN_JDK_VERSION} \
     && microdnf clean all \
     && echo "===> Creating appuser and directories..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
                         <ARCH>${arch.type}</ARCH>
                         <GATEWAY_VERSION>${GATEWAY_VERSION}</GATEWAY_VERSION>
                         <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                        <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                        <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-25-jdk.version}</TEMURIN_JDK_VERSION>
                         <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                     </buildArgs>
                 </configuration>
@@ -99,7 +99,7 @@
                                     <ARCH>${arch.type}</ARCH>
                                     <GATEWAY_VERSION>${GATEWAY_VERSION}</GATEWAY_VERSION>
                                     <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                                    <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                                    <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-25-jdk.version}</TEMURIN_JDK_VERSION>
                                     <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                                 </args>
                             </build>
@@ -152,7 +152,7 @@
         <ubi9-minimal.image.version>9.7-1776833838</ubi9-minimal.image.version>
 
         <!-- OS Package Versions -->
-        <ubi9-minimal.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9-minimal.temurin-21-jdk.version>
+        <ubi9-minimal.temurin-25-jdk.version>25.0.2.0.0.10-0</ubi9-minimal.temurin-25-jdk.version>
 
         <!-- GitHub Repository Tags -->
         <git-repo.cp-docker-utils.tag>v1.0.10</git-repo.cp-docker-utils.tag>


### PR DESCRIPTION
### Description
AK added support for Java 25 starting 4.2. Following that CP is adding support for java 25 for CP components starting CP 8.3. This PR updates the gateway images to use JDK 25. This change follows the updates done to common-docker images for JDK 25 https://github.com/confluentinc/common-docker/pull/1588

### JIRA Ticket
https://confluentinc.atlassian.net/browse/CPBR-3687

### Changes Made
Since CP 8.3 will be shipped with Java 25 we are updating the next minor release of independent components i.e gateway in this case, this change updates the Java version used for docker images to JDK 25.

Updates temurin-25-jdk.version to 25.0.2.0.0.10 and updates dockerfile references to JDK 25

**Succesful Docker Image Build:** https://semaphore.ci.confluent.io/workflows/07b8dfe5-f87f-4e25-aa8d-464232f410e0?pipeline_id=23c2ce8e-fa69-4f48-94d7-cd10aacc5c9b