### PR TITLE
CPBR-3628: Migrate gateway-images 1.2.x build to fabric8

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -94,7 +94,7 @@ blocks:
             - ci-tools ci-update-version --direct-pom-edit
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
-            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
+            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
               -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$AMD_ARCH -Darch.type=$AMD_ARCH -Ddocker.os_type=ubi9
               $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true $MAVEN_EXTRA_ARGS
             - . cache-maven store
@@ -127,7 +127,7 @@ blocks:
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
             - ci-tools ci-update-version --direct-pom-edit
-            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
+            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
               -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$ARM_ARCH -Darch.type=$ARM_ARCH -Ddocker.os_type=ubi9
               $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true $MAVEN_EXTRA_ARGS
             - . cache-maven store

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -47,7 +47,14 @@ global_job_config:
         else
             export PLATFORM_LABEL=""
         fi
-      - export PACKAGING_BUILD_ARGS=" -DGATEWAY_VERSION=$GATEWAY_VERSION  -DCONFLUENT_PLATFORM_LABEL=$PLATFORM_LABEL -DALLOW_UNSIGNED=$ALLOW_UNSIGNED"
+      - |
+        # Guard each -D flag: passing an empty value (e.g. -DALLOW_UNSIGNED=) on the
+        # command line overrides the default defined in the docker-fabric8 Maven profile,
+        # causing fabric8 to receive a null build arg and fail the Docker build.
+        export PACKAGING_BUILD_ARGS=""
+        if [[ -n "$GATEWAY_VERSION" ]]; then PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DGATEWAY_VERSION=$GATEWAY_VERSION"; fi
+        if [[ -n "$PLATFORM_LABEL" ]]; then PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PLATFORM_LABEL=$PLATFORM_LABEL"; fi
+        if [[ -n "$ALLOW_UNSIGNED" ]]; then PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DALLOW_UNSIGNED=$ALLOW_UNSIGNED"; fi
       - >-
         if [[ $IS_RELEASE && $PACKAGING_BUILD_NUMBER ]]; then
           if [[ $IS_RC ]]; then

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>[8.0.4-0, 8.0.5-0)</version>
+        <version>[8.2.1-0, 8.2.2-0)</version>
     </parent>
 
     <groupId>io.confluent.gateway-images</groupId>
@@ -76,16 +76,12 @@
             <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>dockerfile-maven-plugin</artifactId>
-                <configuration>
-                    <buildArgs>
-                        <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
-                        <ARCH>${arch.type}</ARCH>
-                        <GATEWAY_VERSION>${GATEWAY_VERSION}</GATEWAY_VERSION>
-                        <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                        <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
-                        <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
-                    </buildArgs>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>package</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>io.fabric8</groupId>


### PR DESCRIPTION
Replaces #220 (old branch had a stuck Airlock push and could not be updated with the CI fix).

Disable Spotify dockerfile-maven-plugin and switch the Maven build to the `docker-fabric8` profile, mirroring the migration done on control-center-next-gen-images 2.5.x (PR #194).

Bumps the `common` parent version range from `[8.0.4-0, 8.0.5-0)` to `[8.2.1-0, 8.2.2-0)` because the `docker-fabric8` profile was introduced in common after the 8.0.x series. Companion update in `depot/python/common_tools/data/prod/cpc_gateway_versions.json` keeps release tooling in sync.

Also includes a follow-up fix: guard `PACKAGING_BUILD_ARGS` against empty `-D` flags. Without this, an unset `ALLOW_UNSIGNED` env var produces `-DALLOW_UNSIGNED=` (empty), which overrides the default `ALLOW_UNSIGNED=true` from the `docker-fabric8` profile in common, and fabric8 docker-maven-plugin fails with `null value in entry: ALLOW_UNSIGNED=null`.