### PR TITLE
CPBR-3674: Migrate gateway-images master build to fabric8

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -58,7 +58,14 @@ global_job_config:
         else
             export PLATFORM_LABEL=""
         fi
-      - export PACKAGING_BUILD_ARGS=" -DGATEWAY_VERSION=$GATEWAY_VERSION  -DCONFLUENT_PLATFORM_LABEL=$PLATFORM_LABEL -DALLOW_UNSIGNED=$ALLOW_UNSIGNED"
+      - |
+        # Guard each -D flag: passing an empty value (e.g. -DALLOW_UNSIGNED=) on the
+        # command line overrides the default defined in the docker-fabric8 Maven profile,
+        # causing fabric8 to receive a null build arg and fail the Docker build.
+        export PACKAGING_BUILD_ARGS=""
+        if [[ -n "$GATEWAY_VERSION" ]]; then PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DGATEWAY_VERSION=$GATEWAY_VERSION"; fi
+        if [[ -n "$PLATFORM_LABEL" ]]; then PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PLATFORM_LABEL=$PLATFORM_LABEL"; fi
+        if [[ -n "$ALLOW_UNSIGNED" ]]; then PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DALLOW_UNSIGNED=$ALLOW_UNSIGNED"; fi
       - >-
         if [[ $IS_RELEASE && $PACKAGING_BUILD_NUMBER ]]; then
           if [[ $IS_RC ]]; then
@@ -106,7 +113,7 @@ blocks:
             - ci-tools ci-update-version --direct-pom-edit
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
-            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
+            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
               -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$AMD_ARCH -Darch.type=$AMD_ARCH -Ddocker.os_type=ubi9
               $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true $MAVEN_EXTRA_ARGS
             - . cache-maven store
@@ -202,7 +209,7 @@ blocks:
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
             - ci-tools ci-update-version --direct-pom-edit
-            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
+            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
               -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$ARM_ARCH -Darch.type=$ARM_ARCH -Ddocker.os_type=ubi9
               $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true $MAVEN_EXTRA_ARGS
             - . cache-maven store

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -47,7 +47,14 @@ global_job_config:
         else
             export PLATFORM_LABEL=""
         fi
-      - export PACKAGING_BUILD_ARGS=" -DGATEWAY_VERSION=$GATEWAY_VERSION  -DCONFLUENT_PLATFORM_LABEL=$PLATFORM_LABEL -DALLOW_UNSIGNED=$ALLOW_UNSIGNED"
+      - |
+        # Guard each -D flag: passing an empty value (e.g. -DALLOW_UNSIGNED=) on the
+        # command line overrides the default defined in the docker-fabric8 Maven profile,
+        # causing fabric8 to receive a null build arg and fail the Docker build.
+        export PACKAGING_BUILD_ARGS=""
+        if [[ -n "$GATEWAY_VERSION" ]]; then PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DGATEWAY_VERSION=$GATEWAY_VERSION"; fi
+        if [[ -n "$PLATFORM_LABEL" ]]; then PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PLATFORM_LABEL=$PLATFORM_LABEL"; fi
+        if [[ -n "$ALLOW_UNSIGNED" ]]; then PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DALLOW_UNSIGNED=$ALLOW_UNSIGNED"; fi
       - >-
         if [[ $IS_RELEASE && $PACKAGING_BUILD_NUMBER ]]; then
           if [[ $IS_RC ]]; then
@@ -94,7 +101,7 @@ blocks:
             - ci-tools ci-update-version --direct-pom-edit
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
-            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
+            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
               -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$AMD_ARCH -Darch.type=$AMD_ARCH -Ddocker.os_type=ubi9
               $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true $MAVEN_EXTRA_ARGS
             - . cache-maven store
@@ -127,7 +134,7 @@ blocks:
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
             - ci-tools ci-update-version --direct-pom-edit
-            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
+            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
               -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$ARM_ARCH -Darch.type=$ARM_ARCH -Ddocker.os_type=ubi9
               $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true $MAVEN_EXTRA_ARGS
             - . cache-maven store

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>[8.2.0-0, 8.2.1-0)</version>
+        <version>[8.2.1-0, 8.2.2-0)</version>
     </parent>
 
     <groupId>io.confluent.gateway-images</groupId>
@@ -76,16 +76,12 @@
             <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>dockerfile-maven-plugin</artifactId>
-                <configuration>
-                    <buildArgs>
-                        <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
-                        <ARCH>${arch.type}</ARCH>
-                        <GATEWAY_VERSION>${GATEWAY_VERSION}</GATEWAY_VERSION>
-                        <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                        <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-25-jdk.version}</TEMURIN_JDK_VERSION>
-                        <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
-                    </buildArgs>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>package</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>io.fabric8</groupId>


### PR DESCRIPTION
Mirrors [PR #221](https://github.com/confluentinc/gateway-images/pull/221) (1.2.x fabric8 migration), targeting master (heading to 1.4.x).

Per the [gateway team's response in the s390x rollout thread](https://confluent.slack.com/archives/C08CVAJFTSR/p1779433158832819), s390x will be added on master/1.4.x only — not on 1.2.x or 1.3.x. This PR is the **fabric8 migration prerequisite**; the s390x build/deploy/manifest blocks will come in a follow-up PR mirroring [c-c-n-g-images PR #208](https://github.com/confluentinc/control-center-next-gen-images/pull/208).

## Changes

- **`pom.xml`**
  - Disable Spotify `dockerfile-maven-plugin` (`<phase>none</phase>`).
  - Bump `common` parent version range: `[8.2.0-0, 8.2.1-0)` → `[8.2.1-0, 8.2.2-0)`. The public `common-parent` 8.2.0 and 8.2.1 poms only declare the legacy `docker-arm` profile; the rename to `docker-fabric8` only landed on `common` master after the 8.2.1 cut. Internal codeartifact patch builds in the `8.2.1-N` series carry the rename (same range used by [c-c-n-g-images 2.5.x](https://github.com/confluentinc/control-center-next-gen-images/blob/2.5.x/pom.xml#L22-L26)).
  - Fabric8 plugin block is already in the correct nested `<images><image><build><args>` shape on master — left as-is.

- **`.semaphore/semaphore.yml`**
  - Switch Maven build profile: `-P jenkins,docker` → `-P jenkins,docker-fabric8` (both AMD and ARM mvn invocations).
  - Guard `PACKAGING_BUILD_ARGS` construction. The previous one-liner unconditionally appended `-DALLOW_UNSIGNED=$ALLOW_UNSIGNED`, which becomes `-DALLOW_UNSIGNED=` (empty) when the env var is unset in CI. That overrides the `docker-fabric8` profile's default and fabric8 then fails with `null value in entry: ALLOW_UNSIGNED=null`. Each `-D` flag is now conditional on `[[ -n "$VAR" ]]`. Same guard pattern as PR #221 and c-c-n-g-images PR #194.

## Follow-up

Companion **depot PR** to bump `cpc_gateway_versions.json` `1.4.x.confluent.version` from `8.2.0` → `8.2.1` is required so release-tools doesn't revert this parent bump at the next RC cut of master. Can land separately.

## Test plan
- [ ] AMD build passes
- [ ] ARM build passes  
- [ ] Validate built images: `uname -m` and ELF arch of gateway binaries match container platform; Java os.arch matches