### PR TITLE
CPCG-632: drop dnf update in version-compat kafka-maven image

### DIFF
--- a/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
+++ b/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
@@ -6,8 +6,10 @@ FROM confluentinc/cp-kafka:${KAFKA_VERSION}
 
 # Install JDK and tools, then install newer Maven
 USER root
-RUN dnf update -y && \
-    dnf install -y \
+# NOTE: do not run `dnf update -y` here. On the cp-kafka:8.0.0 base it pulls a
+# python3-libs whose _hashlib needs OPENSSL_3.4.0, which the base's bundled
+# /usr/local/lib64/libcrypto.so.3 does not provide, crashing dnf mid-build.
+RUN dnf install -y \
         java-11-openjdk-devel \
         wget \
         curl \


### PR DESCRIPTION
`dnf update -y` on the `cp-kafka:8.0.0` base pulls a `python3-libs` whose `_hashlib` needs `OPENSSL_3.4.0`, which the base's bundled `libcrypto.so.3` doesn't provide, so dnf crashes mid-build and `version_compatibility_tests` fails at harness setup with client `8.0.0`. Only install what's needed.

Unblocks the ubi9-micro migration merge into 1.3.

JIRA: https://confluentinc.atlassian.net/browse/CPCG-632