### PR TITLE
version-compat: drop redundant curl install (conflicts with curl-minimal)

### DIFF
--- a/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
+++ b/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
@@ -9,10 +9,11 @@ USER root
 # NOTE: do not run `dnf update -y` here. On the cp-kafka:8.0.0 base it pulls a
 # python3-libs whose _hashlib needs OPENSSL_3.4.0, which the base's bundled
 # /usr/local/lib64/libcrypto.so.3 does not provide, crashing dnf mid-build.
+# Don't add `curl` here: it conflicts with the base's curl-minimal, which already
+# provides /usr/bin/curl (the tool only needs basic HTTP GET).
 RUN dnf install -y \
         java-11-openjdk-devel \
         wget \
-        curl \
         git && \
     dnf clean all
 


### PR DESCRIPTION
## Problem
The gateway version-compatibility run fails while **building the `kafka-client-test` image** (`Dockerfile.kafka-maven`), which builds `FROM cp-kafka:8.0.0`. That UBI9 base already ships **`curl-minimal`**, so `dnf install … curl …` fails:

```
#5 [kafka-client-test 2/7] RUN dnf install -y … curl …
 Problem: curl-minimal-7.76.1-31.el9 conflicts with curl provided by curl-7.76.1-40.el9  (try '--allowerasing')
ERROR: … exit code: 1
❌ Failed to start services in KRaft mode
```
Failing job: https://semaphore.ci.confluent.io/jobs/97a64692-ac15-422a-ab77-d392885537d2

## Fix
Drop `curl` from the `dnf install` list. The base's pre-installed `curl-minimal` already provides `/usr/bin/curl`, and every `curl` use in this tool is basic HTTP(S) GET (`curl -f`/`-s` against `localhost:9190/metrics`, downloads), all of which `curl-minimal` supports. This removes the conflicting package request at the root rather than force-erasing (`--allowerasing` was the alternative).

Added a one-line comment so `curl` isn't re-added (mirrors the existing `dnf update` NOTE in the same file).

## Notes
- `librdkafka/Dockerfile.python-client` has the same `dnf install … curl` pattern and may hit the identical conflict on a UBI9 base — left out of this PR; happy to follow up.
- May also want to land on `master`/`1.3.x` if the tool lives there too.