### PR TITLE
version-compat: drop redundant curl install (conflicts with curl-minimal)

### DIFF
--- a/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
+++ b/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
@@ -9,10 +9,11 @@ USER root
 # NOTE: do not run `dnf update -y` here. On the cp-kafka:8.0.0 base it pulls a
 # python3-libs whose _hashlib needs OPENSSL_3.4.0, which the base's bundled
 # /usr/local/lib64/libcrypto.so.3 does not provide, crashing dnf mid-build.
+# Don't add `curl` here: it conflicts with the base's curl-minimal, which already
+# provides /usr/bin/curl (the tool only needs basic HTTP GET).
 RUN dnf install -y \
         java-11-openjdk-devel \
         wget \
-        curl \
         git && \
     dnf clean all
 


### PR DESCRIPTION
Backport to `1.3.x` of the version-compat `kafka-client-test` build fix.

## Problem
`Dockerfile.kafka-maven` builds `FROM cp-kafka:8.0.0`, whose UBI9 base ships **`curl-minimal`**, so `dnf install … curl …` fails:
```
Problem: curl-minimal-7.76.1-31.el9 conflicts with curl provided by curl-7.76.1-40.el9  (try '--allowerasing')
ERROR: … exit code: 1
```
This aborts the `kafka-client-test` image build, so the version-compatibility run never starts its services.

## Fix
Drop `curl` from the `dnf install` list — the base's pre-installed `curl-minimal` already provides `/usr/bin/curl`, and every `curl` use in this tool is basic HTTP(S) GET (`curl -f`/`-s` against `localhost:9190/metrics`, downloads), all of which `curl-minimal` supports. 
