### PR TITLE
CPCG-632: drop dnf update in version-compat kafka-maven image

### DIFF
--- a/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
+++ b/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
@@ -9,15 +9,14 @@ USER root
 # NOTE: do not run `dnf update -y` here. On the cp-kafka:8.0.0 base it pulls a
 # python3-libs whose _hashlib needs OPENSSL_3.4.0, which the base's bundled
 # /usr/local/lib64/libcrypto.so.3 does not provide, crashing dnf mid-build.
+# Maven 3.9.6 supports Java 17.
 RUN dnf install -y \
         java-11-openjdk-devel \
         wget \
         curl \
         git && \
-    dnf clean all
-
-# Install Maven 3.9.6 (supports Java 17)
-RUN wget https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz && \
+    dnf clean all && \
+    wget https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz && \
     tar xzf apache-maven-3.9.6-bin.tar.gz -C /opt && \
     ln -s /opt/apache-maven-3.9.6 /opt/maven && \
     rm apache-maven-3.9.6-bin.tar.gz

--- a/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
+++ b/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
@@ -6,8 +6,10 @@ FROM confluentinc/cp-kafka:${KAFKA_VERSION}
 
 # Install JDK and tools, then install newer Maven
 USER root
-RUN dnf update -y && \
-    dnf install -y \
+# NOTE: do not run `dnf update -y` here. On the cp-kafka:8.0.0 base it pulls a
+# python3-libs whose _hashlib needs OPENSSL_3.4.0, which the base's bundled
+# /usr/local/lib64/libcrypto.so.3 does not provide, crashing dnf mid-build.
+RUN dnf install -y \
         java-11-openjdk-devel \
         wget \
         curl \

--- a/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
+++ b/gateway-version-compatibility-test-tool/Dockerfile.kafka-maven
@@ -16,7 +16,7 @@ RUN dnf install -y \
         curl \
         git && \
     dnf clean all && \
-    wget https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz && \
+    wget --https-only https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz && \
     tar xzf apache-maven-3.9.6-bin.tar.gz -C /opt && \
     ln -s /opt/apache-maven-3.9.6 /opt/maven && \
     rm apache-maven-3.9.6-bin.tar.gz


### PR DESCRIPTION
Forward-port of #223 (merged to 1.3.x) to master, so the 1.4.x micro line inherits the fix.

`dnf update -y` on the `cp-kafka:8.0.0` base pulls a `python3-libs` whose `_hashlib` needs `OPENSSL_3.4.0`, which the base's bundled `libcrypto.so.3` doesn't provide, so dnf crashes mid-build and `version_compatibility_tests` fails at harness setup with client `8.0.0`. Only install what's needed.

JIRA: https://confluentinc.atlassian.net/browse/CPCG-632
Related: CPCG-643 (1.4.x ubi9-micro adaptation)