### PR TITLE
CPCG-547: bump up golang to 1.26.4 to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <git-repo.cp-docker-utils.tag>v1.0.10</git-repo.cp-docker-utils.tag>
 
         <!-- Docker Hub Images -->
-        <golang.image.version>1.26.2-trixie</golang.image.version>
+        <golang.image.version>1.26.4-trixie</golang.image.version>
 
     </properties>
 </project>


### PR DESCRIPTION
Fixes: [https://confluentinc.atlassian.net/browse/CPCG-547](https://confluentinc.atlassian.net/browse/CPCG-547)

Current stdlib shipped with golang 1.26.2 has a few CVE as listed in the JIRA ticket. 

This MR bumps it up to the recommended 1.26.4 version