### PR TITLE
Fix CVE-2026-34480: bump log4j-core to 2.25.4 via log4j-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>2.25.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>utility-belt</artifactId>
                 <version>8.1.0</version>
@@ -50,13 +57,13 @@
                 <artifactId>jolokia-jvm</artifactId>
                 <version>${jolokia-jvm.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>io.prometheus.jmx</groupId>
                 <artifactId>jmx_prometheus_javaagent</artifactId>
                 <version>${jmx_prometheus_javaagent.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>disk-usage-agent</artifactId>


### PR DESCRIPTION
## What
Fix [CPCG-544](https://confluentinc.atlassian.net/browse/CPCG-544) which was pulled
in transitively at the vulnerable **2.24.3** through `io.confluent:utility-belt:8.1.0`.

Imported `log4j-bom:2.25.4` in the parent `pom.xml` `dependencyManagement`. This
overrides the transitive version and keeps `log4j-api`, `log4j-core`, and
`log4j-slf4j-impl` aligned at the fixed **2.25.4** — without excluding the
logging implementation.

## Verification
`mvn dependency:tree -Dincludes=org.apache.logging.log4j` and the generated SBOM
both show `log4j-api`, `log4j-core`, `log4j-slf4j-impl` all at **2.25.4**, with no
`2.24.3` remaining.

[CPCG-544]: https://confluentinc.atlassian.net/browse/CPCG-544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ