### PR TITLE
CPCG-655: fix version-compat tests for ubi9-micro (no curl)

### DIFF
--- a/gateway-version-compatibility-test-tool/docker-compose-kraft.yml
+++ b/gateway-version-compatibility-test-tool/docker-compose-kraft.yml
@@ -156,12 +156,6 @@ services:
               metrics: true
           advanced:
             useIoUring: false
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9190/metrics || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 30s
   kafka-client-test:
     build:
       context: .
@@ -170,7 +164,7 @@ services:
         KAFKA_VERSION: ${KAFKA_CLIENT_VERSION}
     depends_on:
       gateway:
-        condition: service_healthy
+        condition: service_started
     container_name: kafka-client-test
     volumes:
       - ./ssl:/etc/kafka/secrets

--- a/gateway-version-compatibility-test-tool/docker-compose.yml
+++ b/gateway-version-compatibility-test-tool/docker-compose.yml
@@ -174,12 +174,6 @@ services:
               metrics: true
           advanced:
             useIoUring: false
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9190/metrics || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 30s
   kafka-client-test:
     build:
       context: .
@@ -188,7 +182,7 @@ services:
         KAFKA_VERSION: ${KAFKA_CLIENT_VERSION}
     depends_on:
       gateway:
-        condition: service_healthy
+        condition: service_started
     container_name: kafka-client-test
     volumes:
       - ./ssl:/etc/kafka/secrets

--- a/gateway-version-compatibility-test-tool/librdkafka/docker-compose-librdkafka-kraft.yml
+++ b/gateway-version-compatibility-test-tool/librdkafka/docker-compose-librdkafka-kraft.yml
@@ -147,12 +147,6 @@ services:
               metrics: true
           advanced:
             useIoUring: false
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9190/metrics || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 30s
 
   # Python client container
   librdkafka-client-test:
@@ -163,7 +157,7 @@ services:
         LIBRDKAFKA_VERSION: ${LIBRDKAFKA_CLIENT_VERSION}
     depends_on:
       gateway:
-        condition: service_healthy
+        condition: service_started
     container_name: librdkafka-client-test
     volumes:
       - ../ssl:/etc/kafka/secrets

--- a/gateway-version-compatibility-test-tool/librdkafka/docker-compose-librdkafka-reauth-kraft.yml
+++ b/gateway-version-compatibility-test-tool/librdkafka/docker-compose-librdkafka-reauth-kraft.yml
@@ -142,12 +142,6 @@ services:
                         file: /etc/gateway/config/jaas-gw-swapping.conf
           advanced:
             useIoUring: false
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9190/metrics || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 30s
 
   librdkafka-client-test:
     build:
@@ -157,7 +151,7 @@ services:
         LIBRDKAFKA_VERSION: ${LIBRDKAFKA_CLIENT_VERSION:-2.13.0}
     depends_on:
       gateway:
-        condition: service_healthy
+        condition: service_started
     container_name: librdkafka-client-test
     volumes:
       - ../configs:/mutable-configs

--- a/gateway-version-compatibility-test-tool/librdkafka/docker-compose-librdkafka.yml
+++ b/gateway-version-compatibility-test-tool/librdkafka/docker-compose-librdkafka.yml
@@ -160,12 +160,6 @@ services:
               metrics: true
           advanced:
             useIoUring: false
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9190/metrics || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 30s
 
   # Python client container
   librdkafka-client-test:
@@ -176,7 +170,7 @@ services:
         LIBRDKAFKA_VERSION: ${LIBRDKAFKA_CLIENT_VERSION}
     depends_on:
       gateway:
-        condition: service_healthy
+        condition: service_started
     container_name: librdkafka-client-test
     volumes:
       - ../ssl:/etc/kafka/secrets

--- a/gateway-version-compatibility-test-tool/librdkafka/librdkafka-version-compatibility.sh
+++ b/gateway-version-compatibility-test-tool/librdkafka/librdkafka-version-compatibility.sh
@@ -8,6 +8,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PARENT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 GATEWAY_METRICS="http://localhost:9190/metrics"
+
+# Wait for the gateway admin endpoint to respond. The ubi9-micro gateway image
+# ships without curl, so readiness is polled from the host (which has curl)
+# instead of via an in-container Docker healthcheck.
+wait_for_gateway() {
+    for _ in $(seq 1 30); do
+        curl -sf "$GATEWAY_METRICS" > /dev/null 2>&1 && return 0
+        sleep 2
+    done
+    return 1
+}
 RESULTS_DIR="$PARENT_DIR/compatibility-results/$(date +%Y%m%d_%H%M%S)"
 mkdir -p "$RESULTS_DIR"
 
@@ -128,9 +139,9 @@ run_compatibility_test() {
         return 1
     fi
 
-    # Verify gateway is up
-    echo "Verifying gateway connectivity..."
-    if ! curl -s "$GATEWAY_METRICS" > /dev/null; then
+    # Micro gateway image has no in-container curl; poll readiness from the host.
+    echo "Waiting for gateway to become ready..."
+    if ! wait_for_gateway; then
         echo "SETUP_FAILED: Gateway not responding" > "$RESULTS_DIR/${test_id}_status.txt"
         echo "FAILURE_TYPE: GATEWAY_NOT_RESPONDING" >> "$RESULTS_DIR/${test_id}_status.txt"
         echo "TIMESTAMP: $(date -Iseconds)" >> "$RESULTS_DIR/${test_id}_status.txt"
@@ -241,7 +252,7 @@ EOF
     if ! docker-compose -f docker-compose-librdkafka-reauth-kraft.yml up -d --build; then
         echo "REAUTH_SETUP_FAILED: reauth docker-compose failed to start"
         REAUTH_EXIT_CODE=1
-    elif ! curl -s "$GATEWAY_METRICS" > /dev/null; then
+    elif ! wait_for_gateway; then
         echo "REAUTH_SETUP_FAILED: Gateway not responding"
         docker-compose -f docker-compose-librdkafka-reauth-kraft.yml down -v
         REAUTH_EXIT_CODE=1

--- a/gateway-version-compatibility-test-tool/version-compatibility.sh
+++ b/gateway-version-compatibility-test-tool/version-compatibility.sh
@@ -3,6 +3,17 @@
 # 16 combinations: Java clients only (4×4 matrix)
 
 GATEWAY_METRICS="http://localhost:9190/metrics"
+
+# Wait for the gateway admin endpoint to respond. The ubi9-micro gateway image
+# ships without curl, so readiness is polled from the host (which has curl)
+# instead of via an in-container Docker healthcheck.
+wait_for_gateway() {
+    for _ in $(seq 1 30); do
+        curl -sf "$GATEWAY_METRICS" > /dev/null 2>&1 && return 0
+        sleep 2
+    done
+    return 1
+}
 RESULTS_DIR="compatibility-results/$(date +%Y%m%d_%H%M%S)"
 mkdir -p "$RESULTS_DIR"
 
@@ -169,9 +180,10 @@ run_compatibility_test() {
         fi
     fi
     
-    # Health checks will ensure services are ready
-    echo "Services started with health checks - verifying final connectivity..."
-    if ! curl -s "$GATEWAY_METRICS" > /dev/null; then
+    # The ubi9-micro gateway image has no in-container curl, so gateway readiness
+    # is polled from the host instead of via a Docker healthcheck.
+    echo "Waiting for gateway to become ready..."
+    if ! wait_for_gateway; then
         echo "❌ Gateway not responding. Exiting test."
         # Create status file to track the failure
         echo "SETUP_FAILED: Gateway not responding" > "$RESULTS_DIR/${test_id}_status.txt"


### PR DESCRIPTION
CP 8.3's ubi9-micro gateway image ships without curl. The version-compat tests use an in-container healthcheck (`curl localhost:9190/metrics`) that now fails → gateway stuck unhealthy → tests never start.

Fix: move the readiness check to the host (where curl exists) instead of inside the container.

- Remove in-container `healthcheck` from gateway service in all 5 compose files
- Switch `depends_on` from `service_healthy` → `service_started`
- Add `wait_for_gateway` poll in both scripts

## Testing

1. Normal gateway: `./version-compatibility.sh --single 8.0.0 8.0.0` — 42/42 passed
2. No-curl gateway (simulates micro): rebuilt image with curl removed, same suite — 42/42 passed

JIRA: https://confluentinc.atlassian.net/browse/CPCG-655