### PR TITLE
CPBR-3859: Enable s390x docker builds for gateway-images 1.3.x

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -88,6 +88,7 @@ global_job_config:
       - export DOCKER_DEV_TAG="dev-$BRANCH_TAG-$BUILD_NUMBER"
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
+      - export S390X_ARCH=.s390x
 blocks:
   - name: Validation
     dependencies: []
@@ -288,8 +289,96 @@ blocks:
             - export LATEST_PUSH_TAG=$LATEST_TAG$OS_TAG$ARM_ARCH
             - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
             - docker push $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
+  - name: Build S390X
+    dependencies: ["Validation"]
+    run:
+      # don't run the tests on non-functional changes...
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
+    task:
+      jobs:
+        - name: Build S390X ubi9
+          commands:
+            - export OS_TAG="-ubi9"
+            - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
+            - export S390X_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$S390X_ARCH }$S390X_ARCH
+            # Register QEMU binfmt handlers for s390x cross-compilation
+            - docker run --rm --privileged tonistiigi/binfmt --install s390x
+            - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
+            - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
+            - ci-tools ci-update-version --direct-pom-edit
+            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
+              -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$S390X_ARCH -Darch.type=$S390X_ARCH -Ddocker.os_type=ubi9
+              -Ddocker.buildx.platforms=linux/s390x $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true $MAVEN_EXTRA_ARGS
+            - . cache-maven store
+            - for image in $S390X_DOCKER_DEV_FULL_IMAGES; do echo "Pushing $image" && docker push $image; done
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+            - artifact push workflow target --destination target-S390X
+  - name: Deploy S390X confluentinc/cpc-gateway
+    dependencies: ["Build S390X"]
+    run:
+      when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?(-rc[0-9]+)?$'"
+    task:
+      jobs:
+        - name: Deploy S390X confluentinc/cpc-gateway ubi9
+          env_vars:
+            - name: DOCKER_IMAGE
+              value: confluentinc/cpc-gateway
+          commands:
+            - export OS_TAG="-ubi9"
+            - export PROD_IMAGE_NAME=${DOCKER_PROD_REGISTRY}confluentinc/cpc-gateway
+            - export GIT_COMMIT_TAG=$GIT_COMMIT$OS_TAG$S390X_ARCH
+            - export BRANCH_BUILD_TAG=$BRANCH_TAG-$BUILD_NUMBER$OS_TAG$S390X_ARCH
+            - export DEV_IMAGE_FULL=${DOCKER_DEV_REGISTRY}confluentinc/cpc-gateway:$DOCKER_DEV_TAG$OS_TAG$S390X_ARCH
+            - docker pull $DEV_IMAGE_FULL
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
+            - docker push $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
+            - docker push $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
+            - sign-images $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
+            - sign-images $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
+            - export PACKAGE_TAG=$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$S390X_ARCH
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$PACKAGE_TAG
+            - docker push $PROD_IMAGE_NAME:$PACKAGE_TAG
+            - sign-images $PROD_IMAGE_NAME:$PACKAGE_TAG
+            - export LATEST_PUSH_TAG=$LATEST_TAG$OS_TAG$S390X_ARCH
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
+            - docker push $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
+  - name: Deploy S390X confluentinc/confluent-gateway-for-cloud
+    dependencies: ["Build S390X"]
+    run:
+      when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?(-rc[0-9]+)?$'"
+    task:
+      jobs:
+        - name: Deploy S390X confluentinc/confluent-gateway-for-cloud ubi9
+          env_vars:
+            - name: DOCKER_IMAGE
+              value: confluentinc/confluent-gateway-for-cloud
+          commands:
+            - export OS_TAG="-ubi9"
+            - export PROD_IMAGE_NAME=${DOCKER_PROD_REGISTRY}confluentinc/confluent-gateway-for-cloud
+            - export GIT_COMMIT_TAG=$GIT_COMMIT$OS_TAG$S390X_ARCH
+            - export BRANCH_BUILD_TAG=$BRANCH_TAG-$BUILD_NUMBER$OS_TAG$S390X_ARCH
+            - export DEV_IMAGE_FULL=${DOCKER_DEV_REGISTRY}confluentinc/confluent-gateway-for-cloud:$DOCKER_DEV_TAG$OS_TAG$S390X_ARCH
+            - docker pull $DEV_IMAGE_FULL
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
+            - docker push $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
+            - docker push $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
+            - sign-images $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
+            - sign-images $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
+            - export PACKAGE_TAG=$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$S390X_ARCH
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$PACKAGE_TAG
+            - docker push $PROD_IMAGE_NAME:$PACKAGE_TAG
+            - sign-images $PROD_IMAGE_NAME:$PACKAGE_TAG
+            - export LATEST_PUSH_TAG=$LATEST_TAG$OS_TAG$S390X_ARCH
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
+            - docker push $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
   - name: Create Manifest
-    dependencies: ["Deploy AMD confluentinc/cpc-gateway", "Deploy ARM confluentinc/cpc-gateway", "Deploy AMD confluentinc/confluent-gateway-for-cloud", "Deploy ARM confluentinc/confluent-gateway-for-cloud"]
+    dependencies: ["Deploy AMD confluentinc/cpc-gateway", "Deploy ARM confluentinc/cpc-gateway", "Deploy S390X confluentinc/cpc-gateway", "Deploy AMD confluentinc/confluent-gateway-for-cloud", "Deploy ARM confluentinc/confluent-gateway-for-cloud", "Deploy S390X confluentinc/confluent-gateway-for-cloud"]
     run:
       when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?(-rc[0-9]+)?$'"
     task:
@@ -303,20 +392,20 @@ blocks:
               do
                 export OS_TAG="-ubi9"
                 export GIT_TAG=$GIT_COMMIT$OS_TAG
-                docker manifest create $image:$GIT_TAG $image:$GIT_TAG$AMD_ARCH $image:$GIT_TAG$ARM_ARCH
+                docker manifest create $image:$GIT_TAG $image:$GIT_TAG$AMD_ARCH $image:$GIT_TAG$ARM_ARCH $image:$GIT_TAG$S390X_ARCH
                 docker manifest push $image:$GIT_TAG
                 docker pull $image:$GIT_TAG
                 sign-images $image:$GIT_TAG
                 export BRANCH_BUILD_TAG=$BRANCH_TAG-$BUILD_NUMBER$OS_TAG
-                docker manifest create $image:$BRANCH_BUILD_TAG $image:$BRANCH_BUILD_TAG$AMD_ARCH $image:$BRANCH_BUILD_TAG$ARM_ARCH
+                docker manifest create $image:$BRANCH_BUILD_TAG $image:$BRANCH_BUILD_TAG$AMD_ARCH $image:$BRANCH_BUILD_TAG$ARM_ARCH $image:$BRANCH_BUILD_TAG$S390X_ARCH
                 docker manifest push $image:$BRANCH_BUILD_TAG
                 docker pull $image:$BRANCH_BUILD_TAG
                 sign-images $image:$BRANCH_BUILD_TAG
                 export PACKAGE_TAG=$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG
-                docker manifest create $image:$PACKAGE_TAG $image:$PACKAGE_TAG$AMD_ARCH $image:$PACKAGE_TAG$ARM_ARCH
+                docker manifest create $image:$PACKAGE_TAG $image:$PACKAGE_TAG$AMD_ARCH $image:$PACKAGE_TAG$ARM_ARCH $image:$PACKAGE_TAG$S390X_ARCH
                 docker manifest push $image:$PACKAGE_TAG
                 export LATEST_MANIFEST_TAG=$LATEST_TAG$OS_TAG
-                docker manifest create $image:$LATEST_MANIFEST_TAG $image:$LATEST_MANIFEST_TAG$AMD_ARCH $image:$LATEST_MANIFEST_TAG$ARM_ARCH
+                docker manifest create $image:$LATEST_MANIFEST_TAG $image:$LATEST_MANIFEST_TAG$AMD_ARCH $image:$LATEST_MANIFEST_TAG$ARM_ARCH $image:$LATEST_MANIFEST_TAG$S390X_ARCH
                 docker manifest push $image:$LATEST_MANIFEST_TAG
               done
   - name: Push docker images tags summary to artifacts

--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -46,6 +46,7 @@ global_job_config:
       - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
+      - export S390X_ARCH=.s390x
 
 blocks:
   - name: Promote AMD
@@ -180,8 +181,74 @@ blocks:
                   docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
                   docker push $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
               fi
+  - name: Promote S390X
+    dependencies: []
+    task:
+      jobs:
+        - name: Promote confluentinc/cpc-gateway ubi9 S390X
+          env_vars:
+            - name: DOCKER_IMAGE
+              value: confluentinc/cpc-gateway
+          commands:
+            - export OS_TYPE="ubi9"
+            - export DOCKER_REPO="confluentinc/cpc-gateway"
+            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
+            - export INTERNAL_IMAGE_TAG="$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$S390X_ARCH"
+            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG$S390X_ARCH"
+            - docker pull $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG
+            - docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$PROMOTED_TAG
+            - docker run --rm $DOCKER_REPO:$PROMOTED_TAG sh -c "grep staging /etc/yum.repos.d/confluent.repo || grep staging /etc/apt/sources.list" || export STAGING_CHECK_SUCCEED="true"
+            - if [[ ! "$STAGING_CHECK_SUCCEED" ]]; then echo "Detected there was a staging repo in image $DOCKER_REPO:$PROMOTED_TAG refusing to promote." && exit 1; fi
+            - docker push $DOCKER_REPO:$PROMOTED_TAG
+            - >-
+              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
+                  export APPLY_TAG=$GATEWAY_VERSION$S390X_ARCH
+                  docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$APPLY_TAG
+                  docker push $DOCKER_REPO:$APPLY_TAG
+                  export APPLIED="true"
+              fi
+            - >-
+              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
+                  if [[ $APPLIED ]]; then
+                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest$S390X_ARCH
+                  docker push $DOCKER_REPO:latest$S390X_ARCH
+                  fi
+                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$S390X_ARCH
+                  docker push $DOCKER_REPO:latest-$OS_TYPE$S390X_ARCH
+              fi
+        - name: Promote confluentinc/confluent-gateway-for-cloud ubi9 S390X
+          env_vars:
+            - name: DOCKER_IMAGE
+              value: confluentinc/confluent-gateway-for-cloud
+          commands:
+            - export OS_TYPE="ubi9"
+            - export DOCKER_REPO="confluentinc/confluent-gateway-for-cloud"
+            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
+            - export INTERNAL_IMAGE_TAG="$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$S390X_ARCH"
+            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG$S390X_ARCH"
+            - docker pull $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG
+            - docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$PROMOTED_TAG
+            - docker run --rm $DOCKER_REPO:$PROMOTED_TAG sh -c "grep staging /etc/yum.repos.d/confluent.repo || grep staging /etc/apt/sources.list" || export STAGING_CHECK_SUCCEED="true"
+            - if [[ ! "$STAGING_CHECK_SUCCEED" ]]; then echo "Detected there was a staging repo in image $DOCKER_REPO:$PROMOTED_TAG refusing to promote." && exit 1; fi
+            - docker push $DOCKER_REPO:$PROMOTED_TAG
+            - >-
+              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
+                  export APPLY_TAG=$GATEWAY_VERSION$S390X_ARCH
+                  docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$APPLY_TAG
+                  docker push $DOCKER_REPO:$APPLY_TAG
+                  export APPLIED="true"
+              fi
+            - >-
+              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
+                  if [[ $APPLIED ]]; then
+                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest$S390X_ARCH
+                  docker push $DOCKER_REPO:latest$S390X_ARCH
+                  fi
+                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$S390X_ARCH
+                  docker push $DOCKER_REPO:latest-$OS_TYPE$S390X_ARCH
+              fi
   - name: Create Manifest
-    dependencies: ["Promote AMD", "Promote ARM"]
+    dependencies: ["Promote AMD", "Promote ARM", "Promote S390X"]
     task:
       jobs:
         - name: Create Manifest confluentinc/cpc-gateway ubi9
@@ -193,21 +260,21 @@ blocks:
             - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
             - export DOCKER_REPO="confluentinc/cpc-gateway"
             - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG"
-            - docker manifest create $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:$PROMOTED_TAG$AMD_ARCH $DOCKER_REPO:$PROMOTED_TAG$ARM_ARCH
+            - docker manifest create $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:$PROMOTED_TAG$AMD_ARCH $DOCKER_REPO:$PROMOTED_TAG$ARM_ARCH $DOCKER_REPO:$PROMOTED_TAG$S390X_ARCH
             - docker manifest push $DOCKER_REPO:$PROMOTED_TAG
             - >-
               if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
-                  docker manifest create $DOCKER_REPO:$GATEWAY_VERSION $DOCKER_REPO:$GATEWAY_VERSION$AMD_ARCH $DOCKER_REPO:$GATEWAY_VERSION$ARM_ARCH
+                  docker manifest create $DOCKER_REPO:$GATEWAY_VERSION $DOCKER_REPO:$GATEWAY_VERSION$AMD_ARCH $DOCKER_REPO:$GATEWAY_VERSION$ARM_ARCH $DOCKER_REPO:$GATEWAY_VERSION$S390X_ARCH
                   docker manifest push $DOCKER_REPO:$GATEWAY_VERSION
                   export APPLIED="true"
               fi
             - >-
               if [[ $UPDATE_LATEST_TAG == "True" ]]; then
                   if [[ $APPLIED ]]; then
-                  docker manifest create $DOCKER_REPO:latest $DOCKER_REPO:latest$AMD_ARCH $DOCKER_REPO:latest$ARM_ARCH
+                  docker manifest create $DOCKER_REPO:latest $DOCKER_REPO:latest$AMD_ARCH $DOCKER_REPO:latest$ARM_ARCH $DOCKER_REPO:latest$S390X_ARCH
                   docker manifest push $DOCKER_REPO:latest
                   fi
-                  docker manifest create $DOCKER_REPO:latest-$OS_TYPE $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
+                  docker manifest create $DOCKER_REPO:latest-$OS_TYPE $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH $DOCKER_REPO:latest-$OS_TYPE$S390X_ARCH
                   docker manifest push $DOCKER_REPO:latest-$OS_TYPE
               fi
         - name: Create Manifest confluentinc/confluent-gateway-for-cloud ubi9
@@ -219,20 +286,20 @@ blocks:
             - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
             - export DOCKER_REPO="confluentinc/confluent-gateway-for-cloud"
             - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG"
-            - docker manifest create $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:$PROMOTED_TAG$AMD_ARCH $DOCKER_REPO:$PROMOTED_TAG$ARM_ARCH
+            - docker manifest create $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:$PROMOTED_TAG$AMD_ARCH $DOCKER_REPO:$PROMOTED_TAG$ARM_ARCH $DOCKER_REPO:$PROMOTED_TAG$S390X_ARCH
             - docker manifest push $DOCKER_REPO:$PROMOTED_TAG
             - >-
               if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
-                  docker manifest create $DOCKER_REPO:$GATEWAY_VERSION $DOCKER_REPO:$GATEWAY_VERSION$AMD_ARCH $DOCKER_REPO:$GATEWAY_VERSION$ARM_ARCH
+                  docker manifest create $DOCKER_REPO:$GATEWAY_VERSION $DOCKER_REPO:$GATEWAY_VERSION$AMD_ARCH $DOCKER_REPO:$GATEWAY_VERSION$ARM_ARCH $DOCKER_REPO:$GATEWAY_VERSION$S390X_ARCH
                   docker manifest push $DOCKER_REPO:$GATEWAY_VERSION
                   export APPLIED="true"
               fi
             - >-
               if [[ $UPDATE_LATEST_TAG == "True" ]]; then
                   if [[ $APPLIED ]]; then
-                  docker manifest create $DOCKER_REPO:latest $DOCKER_REPO:latest$AMD_ARCH $DOCKER_REPO:latest$ARM_ARCH
+                  docker manifest create $DOCKER_REPO:latest $DOCKER_REPO:latest$AMD_ARCH $DOCKER_REPO:latest$ARM_ARCH $DOCKER_REPO:latest$S390X_ARCH
                   docker manifest push $DOCKER_REPO:latest
                   fi
-                  docker manifest create $DOCKER_REPO:latest-$OS_TYPE $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
+                  docker manifest create $DOCKER_REPO:latest-$OS_TYPE $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH $DOCKER_REPO:latest-$OS_TYPE$S390X_ARCH
                   docker manifest push $DOCKER_REPO:latest-$OS_TYPE
               fi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -77,6 +77,7 @@ global_job_config:
       - export DOCKER_DEV_TAG="dev-$BRANCH_TAG-$BUILD_NUMBER"
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
+      - export S390X_ARCH=.s390x
 blocks:
   - name: Validation
     dependencies: []
@@ -145,6 +146,33 @@ blocks:
             - . publish-test-results
             - artifact push workflow target/test-results
             - artifact push workflow target --destination target-ARM
+  - name: Build S390X
+    dependencies: ["Validation"]
+    run:
+      when: "pull_request =~ '.*'"
+    task:
+      jobs:
+        - name: Build S390X ubi9
+          commands:
+            - export OS_TAG="-ubi9"
+            - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
+            - export S390X_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$S390X_ARCH }$S390X_ARCH
+            # Register QEMU binfmt handlers for s390x cross-compilation
+            - docker run --rm --privileged tonistiigi/binfmt --install s390x
+            - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
+            - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
+            - ci-tools ci-update-version --direct-pom-edit
+            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY
+              -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$S390X_ARCH -Darch.type=$S390X_ARCH -Ddocker.os_type=ubi9
+              -Ddocker.buildx.platforms=linux/s390x $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true $MAVEN_EXTRA_ARGS
+            - . cache-maven store
+            - for image in $S390X_DOCKER_DEV_FULL_IMAGES; do echo "Pushing $image" && docker push $image; done
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+            - artifact push workflow target --destination target-S390X
 after_pipeline:
   task:
     agent:
@@ -162,4 +190,5 @@ after_pipeline:
           - checkout
           - artifact pull workflow target-AMD
           - artifact pull workflow target-ARM
+          - artifact pull workflow target-S390X
           - emit-sonarqube-data --run_only_sonar_scan


### PR DESCRIPTION
Adds s390x build/deploy/promote blocks to the 1.3.x pipelines. fabric8 docker build plugin is already enabled on 1.3.x, which the s390x cross-builds rely on.

- semaphore.yml: Build S390X (QEMU binfmt + buildx linux/s390x) on PR builds.
- cp_dockerfile_build.yml: Build S390X + Deploy S390X for both images + s390x in the manifest.
- cp_dockerfile_promote.yml: Promote S390X for both images + s390x in the manifest.

s390x runs on the amd64 agent via QEMU (no native s390x agent for now). No Dockerfile/pom changes needed — the gateway image is noarch, so it cross-builds through the existing fabric8/buildx path.