### PR TITLE
CPCG-625: bump up cp-docker-utils to 1.0.16 to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <ubi9-minimal.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9-minimal.temurin-21-jdk.version>
 
         <!-- GitHub Repository Tags -->
-        <git-repo.cp-docker-utils.tag>v1.0.10</git-repo.cp-docker-utils.tag>
+        <git-repo.cp-docker-utils.tag>v1.0.16</git-repo.cp-docker-utils.tag>
 
         <!-- Docker Hub Images -->
         <golang.image.version>1.26.4-trixie</golang.image.version>


### PR DESCRIPTION
FIxes: https://confluentinc.atlassian.net/browse/CPCG-625

We are using v1.0.10 for cp-docker-utils which is affected by CVE for pkg:golang/golang.org/x/sys@0.43.0

v1.0.16 of cp-docker-utils fixes this CVE by upgrading sys to 0.46.0