### PR TITLE
Exclude and Re-declare log4j

### DIFF
--- a/confluent-gateway-for-cloud/pom.xml
+++ b/confluent-gateway-for-cloud/pom.xml
@@ -27,6 +27,32 @@
     <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>utility-belt</artifactId>
+      <!-- utility-belt pulls in an older log4j (2.24.3); exclude it and
+           re-declare the artifacts we need at ${log4j.version} below. -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- log4j re-declared explicitly (excluded from utility-belt above) -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -27,6 +27,32 @@
     <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>utility-belt</artifactId>
+      <!-- utility-belt pulls in an older log4j (2.24.3); exclude it and
+           re-declare the artifacts we need at ${log4j.version} below. -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- log4j re-declared explicitly (excluded from utility-belt above) -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>utility-belt</artifactId>
-                <version>8.1.0</version>
+                <version>8.1.4-25</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,13 @@
                 <artifactId>jolokia-jvm</artifactId>
                 <version>${jolokia-jvm.version}</version>
             </dependency>
-
+            
             <dependency>
                 <groupId>io.prometheus.jmx</groupId>
                 <artifactId>jmx_prometheus_javaagent</artifactId>
                 <version>${jmx_prometheus_javaagent.version}</version>
             </dependency>
-
+            
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>disk-usage-agent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-bom</artifactId>
-                <version>2.25.4</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>utility-belt</artifactId>
                 <version>8.1.0</version>
@@ -120,6 +113,7 @@
     <properties>
         <component.name>gateway</component.name>
         <io.confluent.gateway-images.version>1.2.0-0</io.confluent.gateway-images.version>
+        <log4j.version>2.25.4</log4j.version>
         <arch.type>.arm64</arch.type>
         <!--  This is a placeholder for the architecture of the image that we will need from input
          and the input will come in mvn command from semaphore.yml file -->


### PR DESCRIPTION
# Log4j Dependency: Exclude-and-Redeclare Refactor
 
### Why version management alone no longer works

Once we exclude log4j from utility-belt, **nothing pulls log4j onto the classpath anymore**, so there's nothing left to "manage." A `<dependencyManagement>` entry would be setting a version for an artifact no module actually depends on — log4j would simply be absent at compile/runtime. It has to be re-added as a **real `<dependencies>` declaration**, not a managed one.

### Why the real declaration can't go in the parent's top level

A parent's top-level `<dependencies>` *are* inherited — but **unconditionally, by every child**, including `gateway-version-compatibility-test-tool`, which doesn't use utility-belt (it uses `slf4j-simple`). Putting log4j there would force `log4j-core` onto a module that neither needs nor wants it.

So the exclude-and-redeclare has to live in the two modules that actually consume utility-belt — `gateway/pom.xml` and `confluent-gateway-for-cloud/pom.xml` — which is why the change touches those files plus the parent for the centralized `${log4j.version}` property.

### Summary

- **Parent `pom.xml`** — defines `${log4j.version}` as the single source of truth.
- **`gateway/pom.xml` and `confluent-gateway-for-cloud/pom.xml`** — exclude log4j from utility-belt and re-declare it, because the real dependency declaration cannot live in the parent's top level without leaking into modules that don't use utility-belt.