### PR TITLE
fix(ci): bootstrap buildx builder before assuming the scoped IAM role

### DIFF
--- a/.semaphore/librdkafka_version_compatibility_tests.yml
+++ b/.semaphore/librdkafka_version_compatibility_tests.yml
@@ -18,6 +18,7 @@ global_job_config:
       - checkout
       - . vault-setup
       - . vault-sem-get-secret v1/ci/kv/cpc-gateway/slack-webhook-tests-notifications
+      - docker buildx inspect --bootstrap buildx-builder || docker buildx inspect --bootstrap
       - . assume-iam-role arn:aws:iam::523370736235:role/root-account-access
       - export RESULTS_TIMESTAMP=$(date +%Y-%m-%d-%H-%M-%S)
       - export S3_BUCKET="gateway-results"

--- a/.semaphore/version_compatibility_tests.yml
+++ b/.semaphore/version_compatibility_tests.yml
@@ -17,6 +17,7 @@ global_job_config:
       - checkout
       - . vault-setup
       - . vault-sem-get-secret v1/ci/kv/cpc-gateway/slack-webhook-tests-notifications
+      - docker buildx inspect --bootstrap buildx-builder || docker buildx inspect --bootstrap
       - . assume-iam-role arn:aws:iam::523370736235:role/root-account-access
       - export RESULTS_TIMESTAMP=$(date +%Y-%m-%d-%H-%M-%S)
       - export S3_BUCKET="gateway-results"


### PR DESCRIPTION
## Problem

The scheduled `version-compatibility-tests` and `librdkafka-version-compatibility-tests` pipelines fail at BuildKit boot. The CI agent's buildx builder now uses the `docker-container` driver, which boots BuildKit by pulling its builder image from a registry at build time. These pipelines assume a scoped IAM role in the prologue before the build, and that role can't pull the builder image — so BuildKit fails to boot and no test combinations run.

This is an agent/infra-side change, not a repo change — the main build pipeline (which doesn't assume that role) builds fine on the same commit.

## Fix

Bootstrap the buildx builder under the agent's default (pull-capable) identity **before** assuming the scoped role; the running BuildKit container is then reused by the later builds without another pull.

```
- docker buildx inspect --bootstrap buildx-builder || docker buildx inspect --bootstrap
```

The `||` fallback bootstraps the current/default builder if it isn't named `buildx-builder`.

## Scope

Temporary CI workaround pending the infra-side fix that removes the build-time builder-image pull. Safe to remove afterward.

## Validation

Ran the full version-compatibility matrix on this branch — BuildKit boots (the bootstrap runs before the role switch) and the suite completes green, no pull-access errors:

- `5476956` — ✅ passed (full matrix, ~2h21m): https://semaphore.ci.confluent.io/workflows/ce5ce8b2-a2af-4505-96bf-aad3e0c611f6
- `0ca003f` (branch HEAD) — ✅ passed (full matrix, ~2h23m), **0 failed / 0 setup failures**: https://semaphore.ci.confluent.io/workflows/7b944a07-495d-4420-bb4a-30932b430a6c