### PR TITLE
Add Gateway-enforced field-level and full-payload encryption to the governance example

### DIFF
--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -29,7 +29,7 @@ The example shows the **four validation levels** (`NONE`, `ID`, `SCHEMA`, `SCHEM
 
 - Docker and Docker Compose
 - Access to the CPC Gateway Docker image
-- A valid **Confluent license JWT** — all three components (Confluent Server, Schema Registry, CPC Gateway) require a license to run. The `SCHEMA_RULES` / encryption scenarios additionally require the **CSFLE add-on** on the license.
+- A valid **Confluent license JWT** — all three components (Confluent Server, Schema Registry, CPC Gateway) require a license to run. The encryption scenarios (`SCHEMA_RULES`) require the **CPC license** for CPC Gateway, or the **CC Gateway license** for CC Gateway.
 
 ## Quick Start
 

--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -77,8 +77,9 @@ The registration script creates these schemas:
 | **1** | `Order` | `order_id, product, quantity, price` | `orders-value`, `gov-id-value`, `gov-schema-value` |
 | **2** | `Event` | `event_id, kind` | `events-value` |
 | **3** | `Payment` | `payment_id, card_number (PII), amount` | `gov-encrypt-field-value` |
+| **4** | `Transaction` | `txn_id, account, amount` | `gov-encrypt-payload-value` |
 
-The `Payment` schema tags `card_number` with `confluent:tags: ["PII"]` and carries a data-contract **`ENCRYPT` rule** targeting that tag — see [Field-Level Encryption](#field-level-encryption-schema_rules) below.
+The `Payment` schema tags `card_number` with `confluent:tags: ["PII"]` and carries a data-contract **`ENCRYPT` rule** targeting that tag — see [Field-Level Encryption](#field-level-encryption-schema_rules) below. The `Transaction` schema carries an **`ENCRYPT_PAYLOAD` rule** that encrypts the whole record — see [Full-Payload Encryption](#full-payload-encryption-schema_rules) below.
 
 ### Topics and their validation levels
 
@@ -90,6 +91,7 @@ Topics are auto-created on first produce. Each is pinned to a validation level v
 | `gov-id`           | `ID`           | `gov-id-value`           | `Order` (id 1) |
 | `gov-schema`       | `SCHEMA`       | `gov-schema-value`       | `Order` (id 1) |
 | `gov-encrypt-field`| `SCHEMA_RULES` | `gov-encrypt-field-value`| `Payment` (id 3) — `card_number` encrypted at the Gateway |
+| `gov-encrypt-payload`| `SCHEMA_RULES` | `gov-encrypt-payload-value`| `Transaction` (id 4) — whole record encrypted at the Gateway |
 
 ### What each validation level enforces
 
@@ -218,6 +220,49 @@ docker exec schema-registry kafka-avro-console-consumer \
 
 Only `card_number` is encrypted (it's the only PII-tagged field); `payment_id` and `amount` stay in the clear.
 
+### Full-Payload Encryption (SCHEMA_RULES)
+
+Field-level encryption protects tagged fields. **Full-payload encryption** protects the *entire* record: the `Transaction` schema (id 4) on `gov-encrypt-payload` carries an `ENCRYPT_PAYLOAD` rule (an *encoding* rule, not a field rule), so the **Gateway encrypts the whole serialized value** before it reaches the broker. As with field-level encryption this is *offloaded* — the producer sends plaintext (`rule.executors._default_.disabled=true`) and holds no key.
+
+**Produce a `Transaction` (client sends plaintext; Gateway encrypts the whole record):**
+```bash
+echo '{"txn_id":"T1","account":"ACME-001","amount":9999.0}' | \
+docker exec -i schema-registry kafka-avro-console-producer \
+  --bootstrap-server gateway:6969 --topic gov-encrypt-payload \
+  --property schema.registry.url=http://schema-registry:8081 \
+  --property value.schema.id=4 --property auto.register.schemas=false \
+  --property rule.executors._default_.disabled=true \
+  --producer-property security.protocol=SASL_PLAINTEXT \
+  --producer-property sasl.mechanism=PLAIN \
+  --producer-property sasl.jaas.config="$JAAS"
+```
+
+**(a) Read the raw bytes straight from the broker (bypassing the Gateway) — the whole value is ciphertext (no field is readable):**
+```bash
+docker exec kafka kafka-console-consumer \
+  --bootstrap-server kafka:29092 --topic gov-encrypt-payload --from-beginning --timeout-ms 6000 \
+  --consumer-property security.protocol=SASL_PLAINTEXT \
+  --consumer-property sasl.mechanism=PLAIN \
+  --consumer-property sasl.jaas.config="$JAAS"
+# e.g. <schema-id prefix><binary ciphertext> — neither "T1" nor "ACME-001" appears
+```
+
+**(b) Read back through the Gateway — the record is decrypted:**
+```bash
+docker exec schema-registry kafka-avro-console-consumer \
+  --bootstrap-server gateway:6969 --topic gov-encrypt-payload --from-beginning \
+  --property schema.registry.url=http://schema-registry:8081 \
+  --property rule.executors._default_.disabled=true \
+  --consumer-property security.protocol=SASL_PLAINTEXT \
+  --consumer-property sasl.mechanism=PLAIN \
+  --consumer-property sasl.jaas.config="$JAAS"
+# {"txn_id":"T1","account":"ACME-001","amount":9999.0}
+```
+
+Unlike field-level encryption, **no field stays in the clear** — `txn_id`, `account`, and `amount` are all inside the encrypted payload.
+
+> **Field vs full-payload:** field-level (`ENCRYPT`) targets tagged fields and leaves the rest readable — good for selective PII protection while keeping the record partially queryable. Full-payload (`ENCRYPT_PAYLOAD`) encrypts everything — good when the whole record is sensitive.
+
 ### Verify — consume to confirm what landed
 
 ```bash
@@ -240,6 +285,7 @@ Only accepted records appear — rejected records never reached the broker.
 | 4 | `gov-id` (ID) | id=1 prefix + garbage | accepted |
 | 4 | `gov-schema` (SCHEMA) | id=1 prefix + garbage | rejected (`Error deserializing Avro message`) |
 | 5 | `gov-encrypt-field` (SCHEMA_RULES) | `Payment` id=3 plaintext | accepted; `card_number` encrypted at rest, decrypted on read-back |
+| 6 | `gov-encrypt-payload` (SCHEMA_RULES) | `Transaction` id=4 plaintext | accepted; whole record encrypted at rest, decrypted on read-back |
 
 ## Gateway Configuration
 
@@ -251,12 +297,14 @@ gateway:
     keyValidationLevel: NONE
     valueValidationLevel: ID          # default for any topic not listed below
     valueSubjectNameStrategy: TOPIC   # subject = {topic}-value
-    # Local KMS secret so the Gateway can run the CSFLE field-encryption rule
-    # on behalf of clients (demo secret only — use a real KMS in production).
+    # Local KMS secret so the Gateway can run encryption rules centrally
+    # (demo secret only — use a real KMS in production).
     schemaRegistryConfigs:
-      rule.executors: "encryptField"
+      rule.executors: "encryptField,encryptPayload"
       rule.executors.encryptField.class: "io.confluent.kafka.schemaregistry.encryption.FieldEncryptionExecutor"
       rule.executors.encryptField.param.secret: "<base64-local-kms-secret>"
+      rule.executors.encryptPayload.class: "io.confluent.kafka.schemaregistry.encryption.EncryptionExecutor"
+      rule.executors.encryptPayload.param.secret: "<base64-local-kms-secret>"
     topics:
       - name: gov-none
         valueValidationLevel: NONE
@@ -265,6 +313,8 @@ gateway:
       - name: gov-schema
         valueValidationLevel: SCHEMA
       - name: gov-encrypt-field
+        valueValidationLevel: SCHEMA_RULES
+      - name: gov-encrypt-payload
         valueValidationLevel: SCHEMA_RULES
 ```
 

--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -70,12 +70,15 @@ This starts three containers:
 
 ### Schemas and subjects
 
-The registration script creates **two distinct schemas**:
+The registration script creates these schemas:
 
 | Schema ID | Schema | Fields | Registered under subjects |
 |---|---|---|---|
 | **1** | `Order` | `order_id, product, quantity, price` | `orders-value`, `gov-id-value`, `gov-schema-value` |
 | **2** | `Event` | `event_id, kind` | `events-value` |
+| **3** | `Payment` | `payment_id, card_number (PII), amount` | `gov-encrypt-field-value` |
+
+The `Payment` schema tags `card_number` with `confluent:tags: ["PII"]` and carries a data-contract **`ENCRYPT` rule** targeting that tag — see [Field-Level Encryption](#field-level-encryption-schema_rules) below.
 
 ### Topics and their validation levels
 
@@ -83,10 +86,10 @@ Topics are auto-created on first produce. Each is pinned to a validation level v
 
 | Topic | Validation level | Expected value subject | Conforming schema |
 |---|---|---|---|
-| `gov-none`   | `NONE`         | — | anything (no checks) |
-| `gov-id`     | `ID`           | `gov-id-value`     | `Order` (id 1) |
-| `gov-schema` | `SCHEMA`       | `gov-schema-value` | `Order` (id 1) |
-| `gov-rules`  | `SCHEMA_RULES` | `gov-rules-value`  | data-contract rules (incl. field-level encryption) |
+| `gov-none`         | `NONE`         | — | anything (no checks) |
+| `gov-id`           | `ID`           | `gov-id-value`           | `Order` (id 1) |
+| `gov-schema`       | `SCHEMA`       | `gov-schema-value`       | `Order` (id 1) |
+| `gov-encrypt-field`| `SCHEMA_RULES` | `gov-encrypt-field-value`| `Payment` (id 3) — `card_number` encrypted at the Gateway |
 
 ### What each validation level enforces
 
@@ -170,6 +173,51 @@ docker exec -i kafka bash -c "printf '\x00\x00\x00\x00\x01GARBAGE' | \
 ```
 This is the one test that distinguishes `ID` from `SCHEMA`: `ID` only checks the schema ID resolves; `SCHEMA` also deserializes the payload.
 
+### Field-Level Encryption (SCHEMA_RULES)
+
+At `SCHEMA_RULES` level the Gateway runs the schema's data-contract rules. The `Payment` schema (id 3) on `gov-encrypt-field` carries an `ENCRYPT` rule for its PII-tagged `card_number` field, so the **Gateway encrypts that field** before it reaches the broker — the producer sends plaintext and holds no key. This is *offloaded* encryption: the KMS secret lives only in the Gateway (`gateway.yaml` → `schemaRegistryConfigs`), not in any client.
+
+Because the client must send **plaintext** (the Gateway does the encrypting), the producer disables client-side rule execution with `rule.executors._default_.disabled=true`.
+
+> **Schema Registry setup:** storing data-contract rules and the data encryption keys requires SR to load two resource extensions (already set in `docker-compose.yaml`): `RuleSetResourceExtension` (persists the `ruleSet`) and `DekRegistryResourceExtension` (the DEK registry). Without the first, SR silently drops the `ruleSet` and no encryption happens.
+
+**Produce a `Payment` (client sends plaintext; Gateway encrypts `card_number`):**
+```bash
+echo '{"payment_id":"P1","card_number":"4111-2222-3333-4444","amount":42.5}' | \
+docker exec -i schema-registry kafka-avro-console-producer \
+  --broker-list gateway:6969 --topic gov-encrypt-field \
+  --property schema.registry.url=http://schema-registry:8081 \
+  --property value.schema.id=3 --property auto.register.schemas=false \
+  --property rule.executors._default_.disabled=true \
+  --producer-property security.protocol=SASL_PLAINTEXT \
+  --producer-property sasl.mechanism=PLAIN \
+  --producer-property sasl.jaas.config="$JAAS"
+```
+
+**(a) Read the raw bytes straight from the broker (bypassing the Gateway) — `card_number` is ciphertext, `payment_id` stays plaintext:**
+```bash
+docker exec kafka kafka-console-consumer \
+  --bootstrap-server kafka:29092 --topic gov-encrypt-field --from-beginning --timeout-ms 6000 \
+  --consumer-property security.protocol=SASL_PLAINTEXT \
+  --consumer-property sasl.mechanism=PLAIN \
+  --consumer-property sasl.jaas.config="$JAAS"
+# e.g. ...P1<binary>Ln9rEaAQDjSwUtT6sEmQwgQw2XogpK8ADckjogUJhkIz...=  (card_number encrypted)
+```
+
+**(b) Read back through the Gateway — `card_number` is decrypted:**
+```bash
+docker exec schema-registry kafka-avro-console-consumer \
+  --bootstrap-server gateway:6969 --topic gov-encrypt-field --from-beginning \
+  --property schema.registry.url=http://schema-registry:8081 \
+  --property rule.executors._default_.disabled=true \
+  --consumer-property security.protocol=SASL_PLAINTEXT \
+  --consumer-property sasl.mechanism=PLAIN \
+  --consumer-property sasl.jaas.config="$JAAS"
+# {"payment_id":"P1","card_number":"4111-2222-3333-4444","amount":42.5}
+```
+
+Only `card_number` is encrypted (it's the only PII-tagged field); `payment_id` and `amount` stay in the clear.
+
 ### Verify — consume to confirm what landed
 
 ```bash
@@ -191,6 +239,7 @@ Only accepted records appear — rejected records never reached the broker.
 | 3 | `gov-schema` (SCHEMA) | `Event` id=2 (wrong subject) | rejected (`Failed to get schema ... id=2`) |
 | 4 | `gov-id` (ID) | id=1 prefix + garbage | accepted |
 | 4 | `gov-schema` (SCHEMA) | id=1 prefix + garbage | rejected (`Error deserializing Avro message`) |
+| 5 | `gov-encrypt-field` (SCHEMA_RULES) | `Payment` id=3 plaintext | accepted; `card_number` encrypted at rest, decrypted on read-back |
 
 ## Gateway Configuration
 
@@ -202,6 +251,12 @@ gateway:
     keyValidationLevel: NONE
     valueValidationLevel: ID          # default for any topic not listed below
     valueSubjectNameStrategy: TOPIC   # subject = {topic}-value
+    # Local KMS secret so the Gateway can run the CSFLE field-encryption rule
+    # on behalf of clients (demo secret only — use a real KMS in production).
+    schemaRegistryConfigs:
+      rule.executors: "encryptField"
+      rule.executors.encryptField.class: "io.confluent.kafka.schemaregistry.encryption.FieldEncryptionExecutor"
+      rule.executors.encryptField.param.secret: "<base64-local-kms-secret>"
     topics:
       - name: gov-none
         valueValidationLevel: NONE
@@ -209,7 +264,7 @@ gateway:
         valueValidationLevel: ID
       - name: gov-schema
         valueValidationLevel: SCHEMA
-      - name: gov-rules
+      - name: gov-encrypt-field
         valueValidationLevel: SCHEMA_RULES
 ```
 

--- a/examples/governance/README.md
+++ b/examples/governance/README.md
@@ -117,7 +117,7 @@ JAAS='org.apache.kafka.common.security.plain.PlainLoginModule required username=
 ```bash
 echo '{"order_id":"O1","product":"widget","quantity":2,"price":9.99}' | \
 docker exec -i schema-registry kafka-avro-console-producer \
-  --broker-list gateway:6969 --topic gov-schema \
+  --bootstrap-server gateway:6969 --topic gov-schema \
   --property schema.registry.url=http://schema-registry:8081 \
   --property value.schema.id=1 \
   --producer-property security.protocol=SASL_PLAINTEXT \
@@ -131,7 +131,7 @@ docker exec -i schema-registry kafka-avro-console-producer \
 ```bash
 echo "plain-text-no-schema-id" | \
 docker exec -i kafka kafka-console-producer \
-  --broker-list gateway:6969 --topic gov-id \
+  --bootstrap-server gateway:6969 --topic gov-id \
   --producer-property security.protocol=SASL_PLAINTEXT \
   --producer-property sasl.mechanism=PLAIN \
   --producer-property sasl.jaas.config="$JAAS"
@@ -145,7 +145,7 @@ Produce an `Event` record (id 2, registered only under `events-value`) to a topi
 ```bash
 echo '{"event_id":"E1","kind":"click"}' | \
 docker exec -i schema-registry kafka-avro-console-producer \
-  --broker-list gateway:6969 --topic gov-schema \
+  --bootstrap-server gateway:6969 --topic gov-schema \
   --property schema.registry.url=http://schema-registry:8081 \
   --property auto.register.schemas=false --property use.schema.id=2 --property value.schema.id=2 \
   --producer-property security.protocol=SASL_PLAINTEXT \
@@ -161,14 +161,14 @@ The same bytes — a valid id=1 prefix followed by non-Avro garbage — behave d
 ```bash
 # At ID level: ACCEPTED (payload not inspected)
 docker exec -i kafka bash -c "printf '\x00\x00\x00\x00\x01GARBAGE' | \
-  kafka-console-producer --broker-list gateway:6969 --topic gov-id \
+  kafka-console-producer --bootstrap-server gateway:6969 --topic gov-id \
   --producer-property security.protocol=SASL_PLAINTEXT \
   --producer-property sasl.mechanism=PLAIN \
   --producer-property sasl.jaas.config='$JAAS'"
 
 # At SCHEMA level: REJECTED — "Error deserializing Avro message ... id=1"
 docker exec -i kafka bash -c "printf '\x00\x00\x00\x00\x01GARBAGE' | \
-  kafka-console-producer --broker-list gateway:6969 --topic gov-schema \
+  kafka-console-producer --bootstrap-server gateway:6969 --topic gov-schema \
   --producer-property security.protocol=SASL_PLAINTEXT \
   --producer-property sasl.mechanism=PLAIN \
   --producer-property sasl.jaas.config='$JAAS'"
@@ -187,7 +187,7 @@ Because the client must send **plaintext** (the Gateway does the encrypting), th
 ```bash
 echo '{"payment_id":"P1","card_number":"4111-2222-3333-4444","amount":42.5}' | \
 docker exec -i schema-registry kafka-avro-console-producer \
-  --broker-list gateway:6969 --topic gov-encrypt-field \
+  --bootstrap-server gateway:6969 --topic gov-encrypt-field \
   --property schema.registry.url=http://schema-registry:8081 \
   --property value.schema.id=3 --property auto.register.schemas=false \
   --property rule.executors._default_.disabled=true \

--- a/examples/governance/docker-compose.yaml
+++ b/examples/governance/docker-compose.yaml
@@ -52,8 +52,8 @@ services:
       SCHEMA_REGISTRY_SCHEMA_REGISTRY_GROUP_ID: 'schema-registry'
       SCHEMA_REGISTRY_CONFLUENT_LICENSE: ${CONFLUENT_LICENSE:?Set CONFLUENT_LICENSE env var with a valid Enterprise license JWT}
       SCHEMA_REGISTRY_CONFLUENT_LICENSE_ADDON_CSFLE: ${CONFLUENT_LICENSE:?Set CONFLUENT_LICENSE env var with a valid Enterprise license JWT}
-      # Enable data-contract rulesets (RuleSet) + the DEK Registry so CSFLE rules
-      # (SCHEMA_RULES) can be stored and their data encryption keys managed.
+      # Enable data-contract rulesets (RuleSet) + the DEK Registry so encryption
+      # rules (SCHEMA_RULES) can be stored and their data encryption keys managed.
       SCHEMA_REGISTRY_RESOURCE_EXTENSION_CLASS: 'io.confluent.kafka.schemaregistry.rulehandler.RuleSetResourceExtension,io.confluent.dekregistry.DekRegistryResourceExtension'
 
   gateway:

--- a/examples/governance/docker-compose.yaml
+++ b/examples/governance/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       KAFKA_CONFLUENT_LICENSE: ${CONFLUENT_LICENSE:?Set CONFLUENT_LICENSE env var with a valid Enterprise license JWT}
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.9.0
+    image: confluentinc/cp-schema-registry:8.1.0
     container_name: schema-registry
     networks:
       - gateway-network
@@ -51,6 +51,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: 'http://0.0.0.0:8081'
       SCHEMA_REGISTRY_SCHEMA_REGISTRY_GROUP_ID: 'schema-registry'
       SCHEMA_REGISTRY_CONFLUENT_LICENSE: ${CONFLUENT_LICENSE:?Set CONFLUENT_LICENSE env var with a valid Enterprise license JWT}
+      SCHEMA_REGISTRY_CONFLUENT_LICENSE_ADDON_CSFLE: ${CONFLUENT_LICENSE:?Set CONFLUENT_LICENSE env var with a valid Enterprise license JWT}
       # Enable data-contract rulesets (RuleSet) + the DEK Registry so CSFLE rules
       # (SCHEMA_RULES) can be stored and their data encryption keys managed.
       SCHEMA_REGISTRY_RESOURCE_EXTENSION_CLASS: 'io.confluent.kafka.schemaregistry.rulehandler.RuleSetResourceExtension,io.confluent.dekregistry.DekRegistryResourceExtension'

--- a/examples/governance/docker-compose.yaml
+++ b/examples/governance/docker-compose.yaml
@@ -51,6 +51,9 @@ services:
       SCHEMA_REGISTRY_LISTENERS: 'http://0.0.0.0:8081'
       SCHEMA_REGISTRY_SCHEMA_REGISTRY_GROUP_ID: 'schema-registry'
       SCHEMA_REGISTRY_CONFLUENT_LICENSE: ${CONFLUENT_LICENSE:?Set CONFLUENT_LICENSE env var with a valid Enterprise license JWT}
+      # Enable data-contract rulesets (RuleSet) + the DEK Registry so CSFLE rules
+      # (SCHEMA_RULES) can be stored and their data encryption keys managed.
+      SCHEMA_REGISTRY_RESOURCE_EXTENSION_CLASS: 'io.confluent.kafka.schemaregistry.rulehandler.RuleSetResourceExtension,io.confluent.dekregistry.DekRegistryResourceExtension'
 
   gateway:
     image: ${GATEWAY_IMAGE:?Set GATEWAY_IMAGE env var to a CPC Gateway image tag or digest}

--- a/examples/governance/gateway.yaml
+++ b/examples/governance/gateway.yaml
@@ -11,9 +11,10 @@ gateway:
     keyValidationLevel: NONE
     valueValidationLevel: ID
     valueSubjectNameStrategy: TOPIC
-    # Rule executors let the Gateway run CSFLE rules at SCHEMA_RULES level on
-    # behalf of clients: encryptField for field-level ENCRYPT, encryptPayload
-    # for full-payload ENCRYPT_PAYLOAD. The local KMS secret is supplied here.
+    # Rule executors let the Gateway centrally encrypt data and enforce
+    # governance policies at SCHEMA_RULES level: encryptField for field-level
+    # ENCRYPT, encryptPayload for full-payload ENCRYPT_PAYLOAD. The local KMS
+    # secret is supplied here so the encryption runs at the Gateway.
     # NOTE: demo secret only — supply via a real KMS / secret store in production.
     schemaRegistryConfigs:
       rule.executors: "encryptField,encryptPayload"

--- a/examples/governance/gateway.yaml
+++ b/examples/governance/gateway.yaml
@@ -11,14 +11,16 @@ gateway:
     keyValidationLevel: NONE
     valueValidationLevel: ID
     valueSubjectNameStrategy: TOPIC
-    # Rule executor lets the Gateway run the CSFLE field-encryption rule at
-    # SCHEMA_RULES level. The local KMS secret is supplied here so the Gateway
-    # can wrap/unwrap data keys on behalf of clients.
+    # Rule executors let the Gateway run CSFLE rules at SCHEMA_RULES level on
+    # behalf of clients: encryptField for field-level ENCRYPT, encryptPayload
+    # for full-payload ENCRYPT_PAYLOAD. The local KMS secret is supplied here.
     # NOTE: demo secret only — supply via a real KMS / secret store in production.
     schemaRegistryConfigs:
-      rule.executors: "encryptField"
+      rule.executors: "encryptField,encryptPayload"
       rule.executors.encryptField.class: "io.confluent.kafka.schemaregistry.encryption.FieldEncryptionExecutor"
       rule.executors.encryptField.param.secret: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
+      rule.executors.encryptPayload.class: "io.confluent.kafka.schemaregistry.encryption.EncryptionExecutor"
+      rule.executors.encryptPayload.param.secret: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
     # Per-topic overrides demonstrate each validation level on the same route.
     topics:
       - name: gov-none
@@ -28,6 +30,8 @@ gateway:
       - name: gov-schema
         valueValidationLevel: SCHEMA
       - name: gov-encrypt-field
+        valueValidationLevel: SCHEMA_RULES
+      - name: gov-encrypt-payload
         valueValidationLevel: SCHEMA_RULES
 
   streamingDomains:

--- a/examples/governance/gateway.yaml
+++ b/examples/governance/gateway.yaml
@@ -11,6 +11,14 @@ gateway:
     keyValidationLevel: NONE
     valueValidationLevel: ID
     valueSubjectNameStrategy: TOPIC
+    # Rule executor lets the Gateway run the CSFLE field-encryption rule at
+    # SCHEMA_RULES level. The local KMS secret is supplied here so the Gateway
+    # can wrap/unwrap data keys on behalf of clients.
+    # NOTE: demo secret only — supply via a real KMS / secret store in production.
+    schemaRegistryConfigs:
+      rule.executors: "encryptField"
+      rule.executors.encryptField.class: "io.confluent.kafka.schemaregistry.encryption.FieldEncryptionExecutor"
+      rule.executors.encryptField.param.secret: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
     # Per-topic overrides demonstrate each validation level on the same route.
     topics:
       - name: gov-none
@@ -19,7 +27,7 @@ gateway:
         valueValidationLevel: ID
       - name: gov-schema
         valueValidationLevel: SCHEMA
-      - name: gov-rules
+      - name: gov-encrypt-field
         valueValidationLevel: SCHEMA_RULES
 
   streamingDomains:

--- a/examples/governance/scripts/register-schemas.sh
+++ b/examples/governance/scripts/register-schemas.sh
@@ -7,8 +7,9 @@
 #   orders-value       Order  (Avro)  -> used by the default ID-level route
 #   events-value       Event  (Avro)  -> a *different* schema, used to demo
 #                                          wrong-subject rejection at SCHEMA level
-#   gov-id-value       Order          -> positive case for the ID-level topic
-#   gov-schema-value   Order          -> positive case for the SCHEMA-level topic
+#   gov-id-value             Order      -> positive case for the ID-level topic
+#   gov-schema-value         Order      -> positive case for the SCHEMA-level topic
+#   gov-encrypt-field-value  Payment    -> SCHEMA_RULES: field-level encryption (PII tag)
 
 set -euo pipefail
 
@@ -16,6 +17,11 @@ SR_URL="${SR_URL:-http://localhost:8081}"
 
 ORDER_SCHEMA='{"type":"record","name":"Order","namespace":"io.confluent.demo","fields":[{"name":"order_id","type":"string"},{"name":"product","type":"string"},{"name":"quantity","type":"int"},{"name":"price","type":"double"}]}'
 EVENT_SCHEMA='{"type":"record","name":"Event","namespace":"io.confluent.demo","fields":[{"name":"event_id","type":"string"},{"name":"kind","type":"string"}]}'
+# Payment: the card_number field is tagged PII so the encryption rule targets only that field.
+PAYMENT_SCHEMA='{"type":"record","name":"Payment","namespace":"io.confluent.demo","fields":[{"name":"payment_id","type":"string"},{"name":"card_number","type":"string","confluent:tags":["PII"]},{"name":"amount","type":"double"}]}'
+
+# Encryption KMS params for the field-encryption rule (local KMS for the demo; no cloud KMS needed).
+ENCRYPT_PARAMS='"encrypt.kek.name":"demo-kek","encrypt.kms.type":"local-kms","encrypt.kms.key.id":"demo-key"'
 
 register() {
   local subject="$1" schema="$2"
@@ -24,6 +30,27 @@ register() {
     -H "Content-Type: application/vnd.schemaregistry.v1+json" \
     -d "{\"schemaType\":\"AVRO\",\"schema\":$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$schema")}" \
     | python3 -m json.tool
+  echo ""
+}
+
+# Register a schema together with a field-level encryption ruleSet.
+# The ENCRYPT rule targets fields carrying the given tag (e.g. PII).
+#   $1 subject  $2 schema  $3 rule name  $4 tag (e.g. PII)
+register_field_encrypted() {
+  local subject="$1" schema="$2" rule="$3" tag="$4"
+  echo "==> Registering '${subject}' with field-encryption rule (tag: ${tag})..."
+  local schema_json; schema_json=$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$schema")
+  curl -s -X POST "${SR_URL}/subjects/${subject}/versions" \
+    -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+    -d "{
+      \"schemaType\":\"AVRO\",
+      \"schema\":${schema_json},
+      \"ruleSet\":{\"domainRules\":[{
+        \"name\":\"${rule}\",\"kind\":\"TRANSFORM\",\"type\":\"ENCRYPT\",\"mode\":\"WRITEREAD\",
+        \"tags\":[\"${tag}\"],
+        \"params\":{${ENCRYPT_PARAMS}}
+      }]}
+    }" | python3 -m json.tool
   echo ""
 }
 
@@ -36,6 +63,9 @@ register "orders-value"     "$ORDER_SCHEMA"
 register "events-value"     "$EVENT_SCHEMA"
 register "gov-id-value"     "$ORDER_SCHEMA"
 register "gov-schema-value" "$ORDER_SCHEMA"
+
+# Field-level encryption: only the PII-tagged field (card_number) is encrypted.
+register_field_encrypted "gov-encrypt-field-value" "$PAYMENT_SCHEMA" "encryptPII" "PII"
 
 echo "==> Registered subjects:"
 curl -s "${SR_URL}/subjects" | python3 -m json.tool

--- a/examples/governance/scripts/register-schemas.sh
+++ b/examples/governance/scripts/register-schemas.sh
@@ -7,9 +7,10 @@
 #   orders-value       Order  (Avro)  -> used by the default ID-level route
 #   events-value       Event  (Avro)  -> a *different* schema, used to demo
 #                                          wrong-subject rejection at SCHEMA level
-#   gov-id-value             Order      -> positive case for the ID-level topic
-#   gov-schema-value         Order      -> positive case for the SCHEMA-level topic
-#   gov-encrypt-field-value  Payment    -> SCHEMA_RULES: field-level encryption (PII tag)
+#   gov-id-value              Order        -> positive case for the ID-level topic
+#   gov-schema-value          Order        -> positive case for the SCHEMA-level topic
+#   gov-encrypt-field-value   Payment      -> SCHEMA_RULES: field-level encryption (PII tag)
+#   gov-encrypt-payload-value Transaction  -> SCHEMA_RULES: full-payload encryption
 
 set -euo pipefail
 
@@ -19,9 +20,13 @@ ORDER_SCHEMA='{"type":"record","name":"Order","namespace":"io.confluent.demo","f
 EVENT_SCHEMA='{"type":"record","name":"Event","namespace":"io.confluent.demo","fields":[{"name":"event_id","type":"string"},{"name":"kind","type":"string"}]}'
 # Payment: the card_number field is tagged PII so the encryption rule targets only that field.
 PAYMENT_SCHEMA='{"type":"record","name":"Payment","namespace":"io.confluent.demo","fields":[{"name":"payment_id","type":"string"},{"name":"card_number","type":"string","confluent:tags":["PII"]},{"name":"amount","type":"double"}]}'
+# Transaction: no tags — full-payload encryption encrypts the whole record, not individual fields.
+TRANSACTION_SCHEMA='{"type":"record","name":"Transaction","namespace":"io.confluent.demo","fields":[{"name":"txn_id","type":"string"},{"name":"account","type":"string"},{"name":"amount","type":"double"}]}'
 
 # Encryption KMS params for the field-encryption rule (local KMS for the demo; no cloud KMS needed).
 ENCRYPT_PARAMS='"encrypt.kek.name":"demo-kek","encrypt.kms.type":"local-kms","encrypt.kms.key.id":"demo-key"'
+# Full-payload encryption uses its own KEK so the two scenarios stay independent.
+ENCRYPT_PAYLOAD_PARAMS='"encrypt.kek.name":"demo-kek-payload","encrypt.kms.type":"local-kms","encrypt.kms.key.id":"demo-key"'
 
 register() {
   local subject="$1" schema="$2"
@@ -54,6 +59,27 @@ register_field_encrypted() {
   echo ""
 }
 
+# Register a schema together with a full-payload encryption ruleSet.
+# The ENCRYPT_PAYLOAD rule is an *encoding* rule: it encrypts the whole serialized
+# record (every field), so no field tags are needed.
+#   $1 subject  $2 schema  $3 rule name
+register_payload_encrypted() {
+  local subject="$1" schema="$2" rule="$3"
+  echo "==> Registering '${subject}' with full-payload encryption rule..."
+  local schema_json; schema_json=$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$schema")
+  curl -s -X POST "${SR_URL}/subjects/${subject}/versions" \
+    -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+    -d "{
+      \"schemaType\":\"AVRO\",
+      \"schema\":${schema_json},
+      \"ruleSet\":{\"encodingRules\":[{
+        \"name\":\"${rule}\",\"kind\":\"TRANSFORM\",\"type\":\"ENCRYPT_PAYLOAD\",\"mode\":\"WRITEREAD\",
+        \"params\":{${ENCRYPT_PAYLOAD_PARAMS}}
+      }]}
+    }" | python3 -m json.tool
+  echo ""
+}
+
 echo "==> Waiting for Schema Registry to be ready..."
 until curl -s "${SR_URL}/subjects" > /dev/null 2>&1; do sleep 2; done
 echo "    Schema Registry is ready."
@@ -66,6 +92,9 @@ register "gov-schema-value" "$ORDER_SCHEMA"
 
 # Field-level encryption: only the PII-tagged field (card_number) is encrypted.
 register_field_encrypted "gov-encrypt-field-value" "$PAYMENT_SCHEMA" "encryptPII" "PII"
+
+# Full-payload encryption: the entire Transaction record is encrypted.
+register_payload_encrypted "gov-encrypt-payload-value" "$TRANSACTION_SCHEMA" "encryptPayload"
 
 echo "==> Registered subjects:"
 curl -s "${SR_URL}/subjects" | python3 -m json.tool


### PR DESCRIPTION
## Summary
Builds on #161. Adds **two encryption scenarios** to the governance example where the **Gateway centrally encrypts data and enforces governance policies** — clients send plaintext and the Gateway encrypts on write / decrypts on read. The encryption runs at the Gateway (not the client); the KMS secret lives only in the Gateway config.

This stacks on the validation-levels branch, so the diff here is the encryption delta only. **Review/merge #161 first.**

## Two scenarios

| Scenario | Rule | Topic | What's encrypted |
|----------|------|-------|------------------|
| **Field-level** | `ENCRYPT` (domain rule, targets a `PII` tag) | `gov-encrypt-field` | only the tagged `card_number` field; rest stays readable |
| **Full-payload** | `ENCRYPT_PAYLOAD` (encoding rule) | `gov-encrypt-payload` | the entire serialized record; no field readable |

Producers set `rule.executors._default_.disabled=true` and send plaintext; the Gateway runs the rule via `schemaValidation.schemaRegistryConfigs` (a `FieldEncryptionExecutor` and an `EncryptionExecutor`, each with the local-KMS secret).

## What's included
- `gateway.yaml` — `gov-encrypt-field` and `gov-encrypt-payload` topics at `SCHEMA_RULES`; `encryptField` + `encryptPayload` rule executors (demo secret only; use a real KMS in production)
- `scripts/register-schemas.sh` — `Payment` schema with a field `ENCRYPT` ruleSet, `Transaction` schema with an `ENCRYPT_PAYLOAD` ruleSet
- `docker-compose.yaml` — Schema Registry on **8.1.0** (full-payload `encodingRules` support) + `RuleSetResourceExtension` / `DekRegistryResourceExtension`, with the license supplied for the encryption rules
- `README.md` — field-level and full-payload sections, tests, and results rows

## Test plan (verified end-to-end against the live stack)
- [x] Both rulesets register and persist in SR (`domainRules/ENCRYPT`, `encodingRules/ENCRYPT_PAYLOAD`)
- [x] **Field:** client produces plaintext → Gateway encrypts `card_number` (ciphertext at rest, `payment_id` plaintext) → decrypts on read-back
- [x] **Full-payload:** client produces plaintext → Gateway encrypts the whole record (no field readable at rest) → decrypts on read-back

🤖 Generated with [Claude Code](https://claude.com/claude-code)