### PR TITLE
CPCG-683: Remove config re-rendering to support hot-reload

### DIFF
--- a/confluent-gateway-for-cloud/include/etc/confluent/docker/configure
+++ b/confluent-gateway-for-cloud/include/etc/confluent/docker/configure
@@ -19,29 +19,33 @@
 # Directory for runtime-generated config: the templated/inline config, the node config handed to
 # the Gateway, and licenses. Defaults to a writable path (/tmp/${COMPONENT}) so the Gateway can run
 # under readOnlyRootFilesystem: true; only generated files live here.
-export GATEWAY_TMP_DIR="${GATEWAY_TMP_DIR:-/tmp/${COMPONENT}}"
+GATEWAY_TMP_DIR="${GATEWAY_TMP_DIR:-/tmp/${COMPONENT}}"
 mkdir -p "${GATEWAY_TMP_DIR}"
 
 ub path "${GATEWAY_TMP_DIR}" writable
 
-# GATEWAY_CONFIG if present, put it in ${GATEWAY_TMP_DIR}/gateway-config.yaml and set GATEWAY_CONFIG_FILE
-if [[ -n "${GATEWAY_CONFIG-}" ]]; then
+# Resolve the Gateway config file in priority order:
+#   1. GATEWAY_CONFIG_FILE  - use the file as-is (e.g. mounted by confluent-operator)
+#   2. GATEWAY_CONFIG       - inline config; write it to ${GATEWAY_TMP_DIR}/gateway-config.yaml
+#   3. GATEWAY_CONFIG_TEMPLATE - render the template to ${GATEWAY_TMP_DIR}/gateway-config.yaml
+if [[ -n "${GATEWAY_CONFIG_FILE-}" ]]; then
+  echo "===> Using GATEWAY_CONFIG_FILE environment variable: ${GATEWAY_CONFIG_FILE}"
+elif [[ -n "${GATEWAY_CONFIG-}" ]]; then
   echo "===> Using GATEWAY_CONFIG environment variable"
-  export GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
+  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
   echo "${GATEWAY_CONFIG}" > "${GATEWAY_CONFIG_FILE}"
+elif [[ -n "${GATEWAY_CONFIG_TEMPLATE-}" && -f "${GATEWAY_CONFIG_TEMPLATE}" ]]; then
+  echo "===> Templating configuration file from GATEWAY_CONFIG_TEMPLATE"
+  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
+  ub render-template "${GATEWAY_CONFIG_TEMPLATE}" > "${GATEWAY_CONFIG_FILE}"
 else
-  if [[ -n "${GATEWAY_CONFIG_TEMPLATE-}" && -f "${GATEWAY_CONFIG_TEMPLATE}" ]]; then
-    echo "===> Templating configuration file from GATEWAY_CONFIG_TEMPLATE"
-    export GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
-    ub render-template "${GATEWAY_CONFIG_TEMPLATE}" > "${GATEWAY_CONFIG_FILE}"
-  else
-    echo "===> Using default GATEWAY_CONFIG_FILE: ${GATEWAY_CONFIG_FILE}"
-  fi
+  echo "ERROR: No Gateway config provided. Set one of GATEWAY_CONFIG_FILE, GATEWAY_CONFIG, or GATEWAY_CONFIG_TEMPLATE." >&2
+  exit 1
 fi
 
 echo "===> Checking Licenses Text..."
 if [[ -n "${GATEWAY_LICENSES-}" ]]; then
   echo "===> Using GATEWAY_LICENSES environment variable"
-  export LICENSES_TXT_PATH="${GATEWAY_TMP_DIR}/licenses.txt"
+  LICENSES_TXT_PATH="${GATEWAY_TMP_DIR}/licenses.txt"
   echo "${GATEWAY_LICENSES}" > "${LICENSES_TXT_PATH}"
 fi

--- a/confluent-gateway-for-cloud/include/etc/confluent/docker/run
+++ b/confluent-gateway-for-cloud/include/etc/confluent/docker/run
@@ -21,23 +21,27 @@ echo "===> Configuring Gateway..."
 
 # Directory for runtime-generated config. configure exports this, but exports from a child process
 # do not persist, so resolve it again here with the same default.
-export GATEWAY_TMP_DIR="${GATEWAY_TMP_DIR:-/tmp/${COMPONENT}}"
+GATEWAY_TMP_DIR="${GATEWAY_TMP_DIR:-/tmp/${COMPONENT}}"
 mkdir -p "${GATEWAY_TMP_DIR}" 2>/dev/null || true
 
 # Fail fast with a clear message when the generated-config directory is not writable (e.g. a
 # read-only root filesystem with no writable volume mounted here), instead of letting the app fail
 # later with a confusing "config file does not exist".
 if [ ! -w "${GATEWAY_TMP_DIR}" ]; then
-  echo "ERROR: Gateway generated-config directory '${GATEWAY_TMP_DIR}' is not writable." >&2
+  echo "ERROR: Gateway config directory '${GATEWAY_TMP_DIR}' is not writable." >&2
   echo "       The entrypoint must write the runtime Gateway config here at startup. If the container" >&2
   echo "       root filesystem is read-only (readOnlyRootFilesystem: true), mount a writable volume at" >&2
   echo "       this path or set GATEWAY_TMP_DIR to a writable location." >&2
   exit 1
 fi
 
-# exporting during configure does not persist, so we need to set it again
+# configure runs as a child process, so the variables it exports do not propagate back to run.
+# The contract between configure and run is the file at a well-known path, not the environment:
+# configure writes the resolved config to ${GATEWAY_TMP_DIR}/gateway-config.yaml, and run defaults
+# to that same path here. GATEWAY_CONFIG_FILE is non-empty in our env only when it is a real
+# container env var (e.g. mounted by confluent-operator), which both scripts see directly.
 if [ -z "$GATEWAY_CONFIG_FILE" ]; then
-  export GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
+  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
 fi
 
 if [ -z "$GATEWAY_LOG_REDACTOR_RULES" ] && [ -f "/etc/gateway/log-redactor-rules.json" ]; then
@@ -51,31 +55,11 @@ if [ -f "${GATEWAY_TMP_DIR}/licenses.txt" ]; then
   GATEWAY_START_ARGS+=("-l" "${GATEWAY_TMP_DIR}/licenses.txt")
 fi
 
-config_content=$(<"${GATEWAY_CONFIG_FILE}")
-
-# If GATEWAY_NODE_ID is defined and valid, replace $(gatewayNodeId)
-export GATEWAY_NODE_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-node-config.yaml"
-if [[ -n "${GATEWAY_NODE_ID-}" && "${GATEWAY_NODE_ID}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-  echo "===> Replacing \$(gatewayNodeId) in configuration file with GATEWAY_NODE_ID: ${GATEWAY_NODE_ID}"
-  config_content="${config_content//\$\(gatewayNodeId\)/${GATEWAY_NODE_ID}}"
-  echo "${config_content}" > "${GATEWAY_NODE_CONFIG_FILE}"
-  echo "Updated configuration content: (saved to ${GATEWAY_NODE_CONFIG_FILE}):"
-  # obfuscate any sensitive information in the configuration content before printing
-  obfuscated_config_content=$(echo "${config_content}" | sed -E 's/(password|secret|key|token|value)[=:][^,]+/\1=****/gi')
-  echo "${obfuscated_config_content}"
-else
-  echo "${config_content}" > "${GATEWAY_NODE_CONFIG_FILE}"
+if [ -n "$GATEWAY_NODE_ID" ]; then
+  echo "===> Using GATEWAY_NODE_ID: ${GATEWAY_NODE_ID}"
+  GATEWAY_START_ARGS+=("-n" "${GATEWAY_NODE_ID}")
 fi
 
-# Make sure the node config was actually written before starting the Gateway, so a write failure is
-# reported here clearly instead of as a confusing "config file does not exist" from the app.
-if [ ! -s "${GATEWAY_NODE_CONFIG_FILE}" ]; then
-  echo "ERROR: failed to write Gateway node config to '${GATEWAY_NODE_CONFIG_FILE}'." >&2
-  echo "       Ensure '${GATEWAY_TMP_DIR}' is writable (see the readOnlyRootFilesystem note above)." >&2
-  exit 1
-fi
-
-echo "GATEWAY_NODE_CONFIG_FILE: ${GATEWAY_NODE_CONFIG_FILE} will be used to start the Gateway."
 echo "${GATEWAY_START_ARGS[@]}"
 
-/usr/bin/gateway-start -c "$GATEWAY_NODE_CONFIG_FILE" "${GATEWAY_START_ARGS[@]}" "$@"
+/usr/bin/gateway-start -c "$GATEWAY_CONFIG_FILE" "${GATEWAY_START_ARGS[@]}" "$@"

--- a/confluent-gateway-for-cloud/include/etc/confluent/docker/run
+++ b/confluent-gateway-for-cloud/include/etc/confluent/docker/run
@@ -35,6 +35,11 @@ if [ ! -w "${GATEWAY_TMP_DIR}" ]; then
   exit 1
 fi
 
+# Point the JVM temp dir at the writable generated-config directory. The Gateway writes its
+# generated runtime config under java.io.tmpdir; without this it would default to /tmp, which is
+# not writable under readOnlyRootFilesystem: true.
+export GATEWAY_OPTS="${GATEWAY_OPTS:-} -Djava.io.tmpdir=${GATEWAY_TMP_DIR}"
+
 # configure runs as a child process, so the variables it exports do not propagate back to run.
 # The contract between configure and run is the file at a well-known path, not the environment:
 # configure writes the resolved config to ${GATEWAY_TMP_DIR}/gateway-config.yaml, and run defaults
@@ -42,6 +47,12 @@ fi
 # container env var (e.g. mounted by confluent-operator), which both scripts see directly.
 if [ -z "$GATEWAY_CONFIG_FILE" ]; then
   GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
+fi
+
+if [ ! -f "$GATEWAY_CONFIG_FILE" ]; then
+  echo "ERROR: Gateway config file '${GATEWAY_CONFIG_FILE}' does not exist. Provide one of" >&2
+  echo "       GATEWAY_CONFIG_FILE, GATEWAY_CONFIG, or GATEWAY_CONFIG_TEMPLATE (see configure)." >&2
+  exit 1
 fi
 
 if [ -z "$GATEWAY_LOG_REDACTOR_RULES" ] && [ -f "/etc/gateway/log-redactor-rules.json" ]; then

--- a/gateway/include/etc/confluent/docker/configure
+++ b/gateway/include/etc/confluent/docker/configure
@@ -19,29 +19,33 @@
 # Directory for runtime-generated config: the templated/inline config, the node config handed to
 # the Gateway, and licenses. Defaults to a writable path (/tmp/${COMPONENT}) so the Gateway can run
 # under readOnlyRootFilesystem: true; only generated files live here.
-export GATEWAY_TMP_DIR="${GATEWAY_TMP_DIR:-/tmp/${COMPONENT}}"
+GATEWAY_TMP_DIR="${GATEWAY_TMP_DIR:-/tmp/${COMPONENT}}"
 mkdir -p "${GATEWAY_TMP_DIR}"
 
 ub path "${GATEWAY_TMP_DIR}" writable
 
-# GATEWAY_CONFIG if present, put it in ${GATEWAY_TMP_DIR}/gateway-config.yaml and set GATEWAY_CONFIG_FILE
-if [[ -n "${GATEWAY_CONFIG-}" ]]; then
+# Resolve the Gateway config file in priority order:
+#   1. GATEWAY_CONFIG_FILE  - use the file as-is (e.g. mounted by confluent-operator)
+#   2. GATEWAY_CONFIG       - inline config; write it to ${GATEWAY_TMP_DIR}/gateway-config.yaml
+#   3. GATEWAY_CONFIG_TEMPLATE - render the template to ${GATEWAY_TMP_DIR}/gateway-config.yaml
+if [[ -n "${GATEWAY_CONFIG_FILE-}" ]]; then
+  echo "===> Using GATEWAY_CONFIG_FILE environment variable: ${GATEWAY_CONFIG_FILE}"
+elif [[ -n "${GATEWAY_CONFIG-}" ]]; then
   echo "===> Using GATEWAY_CONFIG environment variable"
-  export GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
+  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
   echo "${GATEWAY_CONFIG}" > "${GATEWAY_CONFIG_FILE}"
+elif [[ -n "${GATEWAY_CONFIG_TEMPLATE-}" && -f "${GATEWAY_CONFIG_TEMPLATE}" ]]; then
+  echo "===> Templating configuration file from GATEWAY_CONFIG_TEMPLATE"
+  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
+  ub render-template "${GATEWAY_CONFIG_TEMPLATE}" > "${GATEWAY_CONFIG_FILE}"
 else
-  if [[ -n "${GATEWAY_CONFIG_TEMPLATE-}" && -f "${GATEWAY_CONFIG_TEMPLATE}" ]]; then
-    echo "===> Templating configuration file from GATEWAY_CONFIG_TEMPLATE"
-    export GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
-    ub render-template "${GATEWAY_CONFIG_TEMPLATE}" > "${GATEWAY_CONFIG_FILE}"
-  else
-    echo "===> Using default GATEWAY_CONFIG_FILE: ${GATEWAY_CONFIG_FILE}"
-  fi
+  echo "ERROR: No Gateway config provided. Set one of GATEWAY_CONFIG_FILE, GATEWAY_CONFIG, or GATEWAY_CONFIG_TEMPLATE." >&2
+  exit 1
 fi
 
 echo "===> Checking Licenses Text..."
 if [[ -n "${GATEWAY_LICENSES-}" ]]; then
   echo "===> Using GATEWAY_LICENSES environment variable"
-  export LICENSES_TXT_PATH="${GATEWAY_TMP_DIR}/licenses.txt"
+  LICENSES_TXT_PATH="${GATEWAY_TMP_DIR}/licenses.txt"
   echo "${GATEWAY_LICENSES}" > "${LICENSES_TXT_PATH}"
 fi

--- a/gateway/include/etc/confluent/docker/run
+++ b/gateway/include/etc/confluent/docker/run
@@ -21,23 +21,27 @@ echo "===> Configuring Gateway..."
 
 # Directory for runtime-generated config. configure exports this, but exports from a child process
 # do not persist, so resolve it again here with the same default.
-export GATEWAY_TMP_DIR="${GATEWAY_TMP_DIR:-/tmp/${COMPONENT}}"
+GATEWAY_TMP_DIR="${GATEWAY_TMP_DIR:-/tmp/${COMPONENT}}"
 mkdir -p "${GATEWAY_TMP_DIR}" 2>/dev/null || true
 
 # Fail fast with a clear message when the generated-config directory is not writable (e.g. a
 # read-only root filesystem with no writable volume mounted here), instead of letting the app fail
 # later with a confusing "config file does not exist".
 if [ ! -w "${GATEWAY_TMP_DIR}" ]; then
-  echo "ERROR: Gateway generated-config directory '${GATEWAY_TMP_DIR}' is not writable." >&2
+  echo "ERROR: Gateway config directory '${GATEWAY_TMP_DIR}' is not writable." >&2
   echo "       The entrypoint must write the runtime Gateway config here at startup. If the container" >&2
   echo "       root filesystem is read-only (readOnlyRootFilesystem: true), mount a writable volume at" >&2
   echo "       this path or set GATEWAY_TMP_DIR to a writable location." >&2
   exit 1
 fi
 
-# exporting during configure does not persist, so we need to set it again
+# configure runs as a child process, so the variables it exports do not propagate back to run.
+# The contract between configure and run is the file at a well-known path, not the environment:
+# configure writes the resolved config to ${GATEWAY_TMP_DIR}/gateway-config.yaml, and run defaults
+# to that same path here. GATEWAY_CONFIG_FILE is non-empty in our env only when it is a real
+# container env var (e.g. mounted by confluent-operator), which both scripts see directly.
 if [ -z "$GATEWAY_CONFIG_FILE" ]; then
-  export GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
+  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
 fi
 
 if [ -z "$GATEWAY_LOG_REDACTOR_RULES" ] && [ -f "/etc/gateway/log-redactor-rules.json" ]; then
@@ -51,31 +55,11 @@ if [ -f "${GATEWAY_TMP_DIR}/licenses.txt" ]; then
   GATEWAY_START_ARGS+=("-l" "${GATEWAY_TMP_DIR}/licenses.txt")
 fi
 
-config_content=$(<"${GATEWAY_CONFIG_FILE}")
-
-# If GATEWAY_NODE_ID is defined and valid, replace $(gatewayNodeId)
-export GATEWAY_NODE_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-node-config.yaml"
-if [[ -n "${GATEWAY_NODE_ID-}" && "${GATEWAY_NODE_ID}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-  echo "===> Replacing \$(gatewayNodeId) in configuration file with GATEWAY_NODE_ID: ${GATEWAY_NODE_ID}"
-  config_content="${config_content//\$\(gatewayNodeId\)/${GATEWAY_NODE_ID}}"
-  echo "${config_content}" > "${GATEWAY_NODE_CONFIG_FILE}"
-  echo "Updated configuration content: (saved to ${GATEWAY_NODE_CONFIG_FILE}):"
-  # obfuscate any sensitive information in the configuration content before printing
-  obfuscated_config_content=$(echo "${config_content}" | sed -E 's/(password|secret|key|token|value)[=:][^,]+/\1=****/gi')
-  echo "${obfuscated_config_content}"
-else
-  echo "${config_content}" > "${GATEWAY_NODE_CONFIG_FILE}"
+if [ -n "$GATEWAY_NODE_ID" ]; then
+  echo "===> Using GATEWAY_NODE_ID: ${GATEWAY_NODE_ID}"
+  GATEWAY_START_ARGS+=("-n" "${GATEWAY_NODE_ID}")
 fi
 
-# Make sure the node config was actually written before starting the Gateway, so a write failure is
-# reported here clearly instead of as a confusing "config file does not exist" from the app.
-if [ ! -s "${GATEWAY_NODE_CONFIG_FILE}" ]; then
-  echo "ERROR: failed to write Gateway node config to '${GATEWAY_NODE_CONFIG_FILE}'." >&2
-  echo "       Ensure '${GATEWAY_TMP_DIR}' is writable (see the readOnlyRootFilesystem note above)." >&2
-  exit 1
-fi
-
-echo "GATEWAY_NODE_CONFIG_FILE: ${GATEWAY_NODE_CONFIG_FILE} will be used to start the Gateway."
 echo "${GATEWAY_START_ARGS[@]}"
 
-/usr/bin/gateway-start -c "$GATEWAY_NODE_CONFIG_FILE" "${GATEWAY_START_ARGS[@]}" "$@"
+/usr/bin/gateway-start -c "$GATEWAY_CONFIG_FILE" "${GATEWAY_START_ARGS[@]}" "$@"

--- a/gateway/include/etc/confluent/docker/run
+++ b/gateway/include/etc/confluent/docker/run
@@ -35,6 +35,11 @@ if [ ! -w "${GATEWAY_TMP_DIR}" ]; then
   exit 1
 fi
 
+# Point the JVM temp dir at the writable generated-config directory. The Gateway writes its
+# generated runtime config under java.io.tmpdir; without this it would default to /tmp, which is
+# not writable under readOnlyRootFilesystem: true.
+export GATEWAY_OPTS="${GATEWAY_OPTS:-} -Djava.io.tmpdir=${GATEWAY_TMP_DIR}"
+
 # configure runs as a child process, so the variables it exports do not propagate back to run.
 # The contract between configure and run is the file at a well-known path, not the environment:
 # configure writes the resolved config to ${GATEWAY_TMP_DIR}/gateway-config.yaml, and run defaults
@@ -42,6 +47,12 @@ fi
 # container env var (e.g. mounted by confluent-operator), which both scripts see directly.
 if [ -z "$GATEWAY_CONFIG_FILE" ]; then
   GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
+fi
+
+if [ ! -f "$GATEWAY_CONFIG_FILE" ]; then
+  echo "ERROR: Gateway config file '${GATEWAY_CONFIG_FILE}' does not exist. Provide one of" >&2
+  echo "       GATEWAY_CONFIG_FILE, GATEWAY_CONFIG, or GATEWAY_CONFIG_TEMPLATE (see configure)." >&2
+  exit 1
 fi
 
 if [ -z "$GATEWAY_LOG_REDACTOR_RULES" ] && [ -f "/etc/gateway/log-redactor-rules.json" ]; then


### PR DESCRIPTION
Stops the entrypoint from generating/re-rendering the gateway config so file-watch hot-reload works: confluent-operator remounts the config in place and the gateway picks it up.

- `run`: pass the mounted config straight through (`-c $GATEWAY_CONFIG_FILE`) and the node id via `-n`; drop the `gateway-node-config.yaml` rewrite. Point `java.io.tmpdir` at the writable `GATEWAY_TMP_DIR`, and fail fast if the config file is missing.
- `configure`: resolve config via `GATEWAY_CONFIG_FILE` > `GATEWAY_CONFIG` > `GATEWAY_CONFIG_TEMPLATE`, else error.

Pairs with gateway PR #209 (node-id substitution moved into the app).