### PR TITLE
Materialize Gateway config into writable runtime dir

### DIFF
--- a/confluent-gateway-for-cloud/include/etc/confluent/docker/configure
+++ b/confluent-gateway-for-cloud/include/etc/confluent/docker/configure
@@ -24,20 +24,25 @@ mkdir -p "${GATEWAY_TMP_DIR}"
 
 ub path "${GATEWAY_TMP_DIR}" writable
 
-# Resolve the Gateway config file in priority order:
-#   1. GATEWAY_CONFIG_FILE  - use the file as-is (e.g. mounted by confluent-operator)
-#   2. GATEWAY_CONFIG       - inline config; write it to ${GATEWAY_TMP_DIR}/gateway-config.yaml
-#   3. GATEWAY_CONFIG_TEMPLATE - render the template to ${GATEWAY_TMP_DIR}/gateway-config.yaml
+# Materialize the resolved Gateway config into the writable runtime path. The Gateway overwrites
+# this file at runtime (via its config HTTP endpoint), so it must live in the writable
+# GATEWAY_TMP_DIR rather than on the read-only operator mount. The source is resolved in priority
+# order:
+#   1. GATEWAY_CONFIG_FILE     - copy the file (e.g. mounted read-only by confluent-operator)
+#   2. GATEWAY_CONFIG          - inline config; write it
+#   3. GATEWAY_CONFIG_TEMPLATE - render the template
+GATEWAY_RUNTIME_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
 if [[ -n "${GATEWAY_CONFIG_FILE-}" ]]; then
-  echo "===> Using GATEWAY_CONFIG_FILE environment variable: ${GATEWAY_CONFIG_FILE}"
+  echo "===> Copying GATEWAY_CONFIG_FILE (${GATEWAY_CONFIG_FILE}) to writable runtime path: ${GATEWAY_RUNTIME_CONFIG_FILE}"
+  if [[ "${GATEWAY_CONFIG_FILE}" != "${GATEWAY_RUNTIME_CONFIG_FILE}" ]]; then
+    cp "${GATEWAY_CONFIG_FILE}" "${GATEWAY_RUNTIME_CONFIG_FILE}"
+  fi
 elif [[ -n "${GATEWAY_CONFIG-}" ]]; then
   echo "===> Using GATEWAY_CONFIG environment variable"
-  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
-  echo "${GATEWAY_CONFIG}" > "${GATEWAY_CONFIG_FILE}"
+  echo "${GATEWAY_CONFIG}" > "${GATEWAY_RUNTIME_CONFIG_FILE}"
 elif [[ -n "${GATEWAY_CONFIG_TEMPLATE-}" && -f "${GATEWAY_CONFIG_TEMPLATE}" ]]; then
   echo "===> Templating configuration file from GATEWAY_CONFIG_TEMPLATE"
-  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
-  ub render-template "${GATEWAY_CONFIG_TEMPLATE}" > "${GATEWAY_CONFIG_FILE}"
+  ub render-template "${GATEWAY_CONFIG_TEMPLATE}" > "${GATEWAY_RUNTIME_CONFIG_FILE}"
 else
   echo "ERROR: No Gateway config provided. Set one of GATEWAY_CONFIG_FILE, GATEWAY_CONFIG, or GATEWAY_CONFIG_TEMPLATE." >&2
   exit 1

--- a/confluent-gateway-for-cloud/include/etc/confluent/docker/run
+++ b/confluent-gateway-for-cloud/include/etc/confluent/docker/run
@@ -42,15 +42,13 @@ export GATEWAY_OPTS="${GATEWAY_OPTS:-} -Djava.io.tmpdir=${GATEWAY_TMP_DIR}"
 
 # configure runs as a child process, so the variables it exports do not propagate back to run.
 # The contract between configure and run is the file at a well-known path, not the environment:
-# configure writes the resolved config to ${GATEWAY_TMP_DIR}/gateway-config.yaml, and run defaults
-# to that same path here. GATEWAY_CONFIG_FILE is non-empty in our env only when it is a real
-# container env var (e.g. mounted by confluent-operator), which both scripts see directly.
-if [ -z "$GATEWAY_CONFIG_FILE" ]; then
-  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
-fi
+# configure materializes the resolved config into this writable runtime path, and run reads it from
+# the same path here. It must be writable (not the read-only operator mount) because the Gateway
+# overwrites it at runtime via its config HTTP endpoint.
+GATEWAY_RUNTIME_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
 
-if [ ! -f "$GATEWAY_CONFIG_FILE" ]; then
-  echo "ERROR: Gateway config file '${GATEWAY_CONFIG_FILE}' does not exist. Provide one of" >&2
+if [ ! -f "$GATEWAY_RUNTIME_CONFIG_FILE" ]; then
+  echo "ERROR: Gateway config file '${GATEWAY_RUNTIME_CONFIG_FILE}' does not exist. Provide one of" >&2
   echo "       GATEWAY_CONFIG_FILE, GATEWAY_CONFIG, or GATEWAY_CONFIG_TEMPLATE (see configure)." >&2
   exit 1
 fi
@@ -73,4 +71,4 @@ fi
 
 echo "${GATEWAY_START_ARGS[@]}"
 
-/usr/bin/gateway-start -c "$GATEWAY_CONFIG_FILE" "${GATEWAY_START_ARGS[@]}" "$@"
+/usr/bin/gateway-start -c "$GATEWAY_RUNTIME_CONFIG_FILE" "${GATEWAY_START_ARGS[@]}" "$@"

--- a/gateway/include/etc/confluent/docker/configure
+++ b/gateway/include/etc/confluent/docker/configure
@@ -24,20 +24,25 @@ mkdir -p "${GATEWAY_TMP_DIR}"
 
 ub path "${GATEWAY_TMP_DIR}" writable
 
-# Resolve the Gateway config file in priority order:
-#   1. GATEWAY_CONFIG_FILE  - use the file as-is (e.g. mounted by confluent-operator)
-#   2. GATEWAY_CONFIG       - inline config; write it to ${GATEWAY_TMP_DIR}/gateway-config.yaml
-#   3. GATEWAY_CONFIG_TEMPLATE - render the template to ${GATEWAY_TMP_DIR}/gateway-config.yaml
+# Materialize the resolved Gateway config into the writable runtime path. The Gateway overwrites
+# this file at runtime (via its config HTTP endpoint), so it must live in the writable
+# GATEWAY_TMP_DIR rather than on the read-only operator mount. The source is resolved in priority
+# order:
+#   1. GATEWAY_CONFIG_FILE     - copy the file (e.g. mounted read-only by confluent-operator)
+#   2. GATEWAY_CONFIG          - inline config; write it
+#   3. GATEWAY_CONFIG_TEMPLATE - render the template
+GATEWAY_RUNTIME_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
 if [[ -n "${GATEWAY_CONFIG_FILE-}" ]]; then
-  echo "===> Using GATEWAY_CONFIG_FILE environment variable: ${GATEWAY_CONFIG_FILE}"
+  echo "===> Copying GATEWAY_CONFIG_FILE (${GATEWAY_CONFIG_FILE}) to writable runtime path: ${GATEWAY_RUNTIME_CONFIG_FILE}"
+  if [[ "${GATEWAY_CONFIG_FILE}" != "${GATEWAY_RUNTIME_CONFIG_FILE}" ]]; then
+    cp "${GATEWAY_CONFIG_FILE}" "${GATEWAY_RUNTIME_CONFIG_FILE}"
+  fi
 elif [[ -n "${GATEWAY_CONFIG-}" ]]; then
   echo "===> Using GATEWAY_CONFIG environment variable"
-  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
-  echo "${GATEWAY_CONFIG}" > "${GATEWAY_CONFIG_FILE}"
+  echo "${GATEWAY_CONFIG}" > "${GATEWAY_RUNTIME_CONFIG_FILE}"
 elif [[ -n "${GATEWAY_CONFIG_TEMPLATE-}" && -f "${GATEWAY_CONFIG_TEMPLATE}" ]]; then
   echo "===> Templating configuration file from GATEWAY_CONFIG_TEMPLATE"
-  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
-  ub render-template "${GATEWAY_CONFIG_TEMPLATE}" > "${GATEWAY_CONFIG_FILE}"
+  ub render-template "${GATEWAY_CONFIG_TEMPLATE}" > "${GATEWAY_RUNTIME_CONFIG_FILE}"
 else
   echo "ERROR: No Gateway config provided. Set one of GATEWAY_CONFIG_FILE, GATEWAY_CONFIG, or GATEWAY_CONFIG_TEMPLATE." >&2
   exit 1

--- a/gateway/include/etc/confluent/docker/run
+++ b/gateway/include/etc/confluent/docker/run
@@ -42,15 +42,13 @@ export GATEWAY_OPTS="${GATEWAY_OPTS:-} -Djava.io.tmpdir=${GATEWAY_TMP_DIR}"
 
 # configure runs as a child process, so the variables it exports do not propagate back to run.
 # The contract between configure and run is the file at a well-known path, not the environment:
-# configure writes the resolved config to ${GATEWAY_TMP_DIR}/gateway-config.yaml, and run defaults
-# to that same path here. GATEWAY_CONFIG_FILE is non-empty in our env only when it is a real
-# container env var (e.g. mounted by confluent-operator), which both scripts see directly.
-if [ -z "$GATEWAY_CONFIG_FILE" ]; then
-  GATEWAY_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
-fi
+# configure materializes the resolved config into this writable runtime path, and run reads it from
+# the same path here. It must be writable (not the read-only operator mount) because the Gateway
+# overwrites it at runtime via its config HTTP endpoint.
+GATEWAY_RUNTIME_CONFIG_FILE="${GATEWAY_TMP_DIR}/gateway-config.yaml"
 
-if [ ! -f "$GATEWAY_CONFIG_FILE" ]; then
-  echo "ERROR: Gateway config file '${GATEWAY_CONFIG_FILE}' does not exist. Provide one of" >&2
+if [ ! -f "$GATEWAY_RUNTIME_CONFIG_FILE" ]; then
+  echo "ERROR: Gateway config file '${GATEWAY_RUNTIME_CONFIG_FILE}' does not exist. Provide one of" >&2
   echo "       GATEWAY_CONFIG_FILE, GATEWAY_CONFIG, or GATEWAY_CONFIG_TEMPLATE (see configure)." >&2
   exit 1
 fi
@@ -73,4 +71,4 @@ fi
 
 echo "${GATEWAY_START_ARGS[@]}"
 
-/usr/bin/gateway-start -c "$GATEWAY_CONFIG_FILE" "${GATEWAY_START_ARGS[@]}" "$@"
+/usr/bin/gateway-start -c "$GATEWAY_RUNTIME_CONFIG_FILE" "${GATEWAY_START_ARGS[@]}" "$@"


### PR DESCRIPTION
Copy/render the resolved config to ${GATEWAY_TMP_DIR}/gateway-config.yaml (writable) in all cases and start the Gateway with that path, instead of pointing -c at the read-only operator mount. This lets the Gateway overwrite its config at runtime (via the planned config HTTP endpoint) rather than relying on the kubelet's ~60s ConfigMap sync for hot-reload.

Applied to both the gateway and confluent-gateway-for-cloud flavors.