### PR TITLE
revert(ci): remove buildx bootstrap workaround now that #2332 bakes the builder into the AMI

### DIFF
--- a/.semaphore/librdkafka_version_compatibility_tests.yml
+++ b/.semaphore/librdkafka_version_compatibility_tests.yml
@@ -18,7 +18,6 @@ global_job_config:
       - checkout
       - . vault-setup
       - . vault-sem-get-secret v1/ci/kv/cpc-gateway/slack-webhook-tests-notifications
-      - docker buildx inspect --bootstrap buildx-builder || docker buildx inspect --bootstrap
       - . assume-iam-role arn:aws:iam::523370736235:role/root-account-access
       - export RESULTS_TIMESTAMP=$(date +%Y-%m-%d-%H-%M-%S)
       - export S3_BUCKET="gateway-results"

--- a/.semaphore/version_compatibility_tests.yml
+++ b/.semaphore/version_compatibility_tests.yml
@@ -17,7 +17,6 @@ global_job_config:
       - checkout
       - . vault-setup
       - . vault-sem-get-secret v1/ci/kv/cpc-gateway/slack-webhook-tests-notifications
-      - docker buildx inspect --bootstrap buildx-builder || docker buildx inspect --bootstrap
       - . assume-iam-role arn:aws:iam::523370736235:role/root-account-access
       - export RESULTS_TIMESTAMP=$(date +%Y-%m-%d-%H-%M-%S)
       - export S3_BUCKET="gateway-results"


### PR DESCRIPTION
## Summary
- Reverts the per-job `docker buildx inspect --bootstrap buildx-builder || docker buildx inspect --bootstrap` workaround added in #242 (INC-11655) to `.semaphore/version_compatibility_tests.yml` and `.semaphore/librdkafka_version_compatibility_tests.yml`.
- The durable fix (`ci-build-agent-infra#2332`, merged 2026-07-07) now bakes the buildx builder image into the AMI and creates `buildx-builder` at boot via `buildx-builder-setup.service`, which `semaphore-agent.service` hard-requires. By the time any job runs, the builder is already live locally — no per-job pull, independent of any IAM role the job later assumes. The workaround is now a redundant no-op.
- Postmortem follow-up for INC-11655 / DP-19416.

## Test plan
- [ ] CI green on this PR (both `version-compatibility-tests` and `librdkafka-version-compatibility-tests` pipelines run BuildKit builds without the bootstrap line)
- [ ] Confirm no "no basic auth credentials" / builder-pull errors reappear

Jira: https://confluentinc.atlassian.net/browse/DP-19416