### PR TITLE
CPBR-3911: Pull Gateway packages from version-isolated <type>/<minor>/

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,6 +31,7 @@ global_job_config:
       - export PACKAGING_BUCKET="s3://dev-gateway-packages-654654529379-us-west-2/confluent-gateway/$BRANCH_TAG/"
       - export LATEST_PACKAGING_BUILD_NUMBER=latest # use packages in latest directory of corresponding nightly branch
       - export GATEWAY_VERSION="1.4.0" #hardcoded for now
+      # packages are version-isolated under <type>/<minor>/ (e.g. rpm/1.4/), so derive the minor
       - export GATEWAY_MAJOR_MINOR=$(echo "$GATEWAY_VERSION" | cut -d. -f1,2)
       - export DEFAULT_OS_TYPE="ubi"
       - export PACKAGES_URL="https://s3-us-west-2.amazonaws.com/dev-gateway-packages-654654529379-us-west-2/confluent-gateway/$BRANCH_TAG/$LATEST_PACKAGING_BUILD_NUMBER/PACKAGE_TYPE/$GATEWAY_MAJOR_MINOR"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,8 +31,9 @@ global_job_config:
       - export PACKAGING_BUCKET="s3://dev-gateway-packages-654654529379-us-west-2/confluent-gateway/$BRANCH_TAG/"
       - export LATEST_PACKAGING_BUILD_NUMBER=latest # use packages in latest directory of corresponding nightly branch
       - export GATEWAY_VERSION="1.4.0" #hardcoded for now
+      - export GATEWAY_MAJOR_MINOR=$(echo "$GATEWAY_VERSION" | cut -d. -f1,2)
       - export DEFAULT_OS_TYPE="ubi"
-      - export PACKAGES_URL="https://s3-us-west-2.amazonaws.com/dev-gateway-packages-654654529379-us-west-2/confluent-gateway/$BRANCH_TAG/$LATEST_PACKAGING_BUILD_NUMBER/PACKAGE_TYPE"
+      - export PACKAGES_URL="https://s3-us-west-2.amazonaws.com/dev-gateway-packages-654654529379-us-west-2/confluent-gateway/$BRANCH_TAG/$LATEST_PACKAGING_BUILD_NUMBER/PACKAGE_TYPE/$GATEWAY_MAJOR_MINOR"
       - export PACKAGING_BUILD_NUMBER=$LATEST_PACKAGING_BUILD_NUMBER
       - >-
         if [[ $IS_BETA || $IS_HOTFIX || $IS_POST ]]; then


### PR DESCRIPTION
Gateway packaging now publishes under `<type>/<minor>/`, so the image build has to pull from the minor dir. Derives the minor from `GATEWAY_VERSION` and appends it to `PACKAGES_URL` in `semaphore.yml`, so the existing `sed PACKAGE_TYPE→rpm` resolves to `.../latest/rpm/1.4`.

The release-flow build already receives the versioned URL from the packaging trigger, and the Dockerfile just consumes the packages repo var, so neither needs changing. Gateway only; ported from control-center-next-gen-images #408.